### PR TITLE
Detect ToReadOnlyCollection in constructors

### DIFF
--- a/src/Faithlife.Analyzers/OperationExtensions.cs
+++ b/src/Faithlife.Analyzers/OperationExtensions.cs
@@ -1,0 +1,23 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Faithlife.Analyzers
+{
+	internal static class OperationExtensions
+	{
+		public static Location GetMethodNameLocation(this IInvocationOperation invocationOperation)
+		{
+			var invocationSyntax = (InvocationExpressionSyntax) invocationOperation.Syntax;
+			switch (invocationSyntax.Expression)
+			{
+			case MemberAccessExpressionSyntax memberAccessExpression:
+				return memberAccessExpression.Name.GetLocation();
+			case ConditionalAccessExpressionSyntax conditionalAccessExpression:
+				return conditionalAccessExpression.WhenNotNull.GetLocation();
+			default:
+				return invocationSyntax.GetLocation();
+			}
+		}
+	}
+}

--- a/src/Faithlife.Analyzers/OverloadWithStringComparisonAnalyzer.cs
+++ b/src/Faithlife.Analyzers/OverloadWithStringComparisonAnalyzer.cs
@@ -31,7 +31,7 @@ namespace Faithlife.Analyzers
 								// wrong overload
 								var rule = (methodSymbol.Name == "Equals" && ((methodSymbol.Parameters.Length == 1 && !methodSymbol.IsStatic) || (methodSymbol.Parameters.Length == 2 && methodSymbol.IsStatic))) ?
 									s_avoidStringEqualsRule : s_useStringComparisonRule;
-								operationContext.ReportDiagnostic(Diagnostic.Create(rule, GetMethodNameLocation(operation.Syntax)));
+								operationContext.ReportDiagnostic(Diagnostic.Create(rule, operation.GetMethodNameLocation()));
 							}
 							else if (methodSymbol.Name == "Equals" && ((methodSymbol.Parameters.Length == 2 && !methodSymbol.IsStatic) || (methodSymbol.Parameters.Length == 3 && methodSymbol.IsStatic)))
 							{
@@ -42,7 +42,7 @@ namespace Faithlife.Analyzers
 									if (fieldSymbol?.ContainingType == stringComparisonType && fieldSymbol.Name == "Ordinal")
 									{
 										// right overload, wrong value
-										operationContext.ReportDiagnostic(Diagnostic.Create(s_avoidStringEqualsRule, GetMethodNameLocation(operation.Syntax)));
+										operationContext.ReportDiagnostic(Diagnostic.Create(s_avoidStringEqualsRule, operation.GetMethodNameLocation()));
 									}
 								}
 							}
@@ -128,19 +128,6 @@ namespace Faithlife.Analyzers
 					methodSymbol.Parameters[3].Type.Equals(stringComparisonType);
 			}
 			return false;
-		}
-
-		private static Location GetMethodNameLocation(SyntaxNode invocationNode)
-		{
-			switch (((InvocationExpressionSyntax) invocationNode).Expression)
-			{
-			case MemberAccessExpressionSyntax memberAccessExpression:
-				return memberAccessExpression.Name.GetLocation();
-			case ConditionalAccessExpressionSyntax conditionalAccessExpression:
-				return conditionalAccessExpression.WhenNotNull.GetLocation();
-			default:
-				return ((InvocationExpressionSyntax) invocationNode).GetLocation();
-			}
 		}
 
 		static readonly DiagnosticDescriptor s_useStringComparisonRule = new DiagnosticDescriptor(

--- a/src/Faithlife.Analyzers/ToReadOnlyCollectionAnalyzer.cs
+++ b/src/Faithlife.Analyzers/ToReadOnlyCollectionAnalyzer.cs
@@ -1,0 +1,62 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Faithlife.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed class ToReadOnlyCollectionAnalyzer : DiagnosticAnalyzer
+	{
+		public override void Initialize(AnalysisContext analysisContext)
+		{
+			analysisContext.RegisterCompilationStartAction(compilationStartAnalysisContext =>
+			{
+				var enumerableUtility = compilationStartAnalysisContext.Compilation.GetTypeByMetadataName("Libronix.Utility.EnumerableUtility");
+				if (enumerableUtility != null)
+				{
+					compilationStartAnalysisContext.RegisterOperationBlockStartAction(context =>
+					{
+						if (context.OwningSymbol is IMethodSymbol methodSymbol && methodSymbol.MethodKind == MethodKind.Constructor)
+							context.RegisterOperationAction(oc => AnalyzeOperation(oc, enumerableUtility), OperationKind.Invocation);
+					});
+				}
+			});
+		}
+
+		public const string DiagnosticId = "FL0005";
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
+
+		private static void AnalyzeOperation(OperationAnalysisContext context, INamedTypeSymbol enumerableUtility)
+		{
+			var invocationOperation = (IInvocationOperation) context.Operation;
+			var targetMethod = invocationOperation.TargetMethod;
+			if (targetMethod.ContainingType == enumerableUtility && targetMethod.Name == "ToReadOnlyCollection")
+			{
+				var expressionStatement = invocationOperation.Syntax.FirstAncestorOrSelf<ExpressionStatementSyntax>();
+				if (expressionStatement?.Expression is AssignmentExpressionSyntax assignmentExpression)
+				{
+					if (assignmentExpression.Left is IdentifierNameSyntax identifierName)
+					{
+						var semanticModel = context.Compilation.GetSemanticModel(identifierName.SyntaxTree);
+						var symbolInfo = semanticModel.GetSymbolInfo(identifierName);
+						var kind = symbolInfo.Symbol.Kind;
+						if (kind == SymbolKind.Field || kind == SymbolKind.Property)
+							context.ReportDiagnostic(Diagnostic.Create(s_rule, invocationOperation.GetMethodNameLocation()));
+					}
+				}
+			}
+		}
+
+		static readonly DiagnosticDescriptor s_rule = new DiagnosticDescriptor(
+			id: DiagnosticId,
+			title: "ToReadOnlyCollection in constructor",
+			messageFormat: "Avoid ToReadOnlyCollection in constructors.",
+			category: "Usage",
+			defaultSeverity: DiagnosticSeverity.Warning,
+			isEnabledByDefault: true,
+			helpLinkUri: $"https://github.com/Faithlife/FaithlifeAnalyzers/wiki/{DiagnosticId}");
+	}
+}

--- a/src/Faithlife.Analyzers/ToReadOnlyCollectionCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/ToReadOnlyCollectionCodeFixProvider.cs
@@ -1,0 +1,64 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Simplification;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Faithlife.Analyzers
+{
+	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CurrentAsyncWorkItemCodeFixProvider)), Shared]
+	public sealed class ToReadOnlyCollectionCodeFixProvider : CodeFixProvider
+	{
+		public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(ToReadOnlyCollectionAnalyzer.DiagnosticId);
+
+		public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+		public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		{
+			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+			var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+
+			var diagnostic = context.Diagnostics.First();
+			var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+			var invocation = root.FindNode(diagnosticSpan).FirstAncestorOrSelf<InvocationExpressionSyntax>();
+			if (invocation is null)
+				return;
+
+			var methodSymbol = semanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol;
+			if (methodSymbol is null)
+				return;
+
+			context.RegisterCodeFix(
+				CodeAction.Create(
+					title: "Use .ToList().AsReadOnly()",
+					createChangedDocument: token => ConvertToToListAsReadOnlyAsync(context.Document, invocation, token),
+					"to-list-as-read-only"),
+				diagnostic);
+		}
+
+		private static async Task<Document> ConvertToToListAsReadOnlyAsync(Document document, InvocationExpressionSyntax invocation, CancellationToken cancellationToken)
+		{
+			var root = (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false))
+				.ReplaceNode(invocation, InvocationExpression(
+						MemberAccessExpression(
+							SyntaxKind.SimpleMemberAccessExpression,
+							InvocationExpression(
+								MemberAccessExpression(
+									SyntaxKind.SimpleMemberAccessExpression,
+									((MemberAccessExpressionSyntax) invocation.Expression).Expression,
+									IdentifierName("ToList"))),
+							IdentifierName("AsReadOnly")))
+					.NormalizeWhitespace());
+
+			return await Simplifier.ReduceAsync(document.WithSyntaxRoot(root), cancellationToken: cancellationToken).ConfigureAwait(false);
+		}
+	}
+}

--- a/tests/Faithlife.Analyzers.Tests/ToReadOnlyCollectionConstructorTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/ToReadOnlyCollectionConstructorTests.cs
@@ -1,0 +1,172 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Framework;
+
+namespace Faithlife.Analyzers.Tests
+{
+	[TestFixture]
+	public class ToReadOnlyCollectionConstructorTests : CodeFixVerifier
+	{
+		[Test]
+		public void EnumerationIsValid()
+		{
+			const string validProgram = c_preamble + @"
+namespace TestApplication
+{
+	public class TestClass
+	{
+		public TestClass(IEnumerable<int> args)
+		{
+			foreach (var arg in args.ToReadOnlyCollection())
+			{
+			}
+		}
+	}
+}";
+			VerifyCSharpDiagnostic(validProgram);
+		}
+
+		[Test]
+		public void VariableDeclarationIsValid()
+		{
+			const string validProgram = c_preamble + @"
+namespace TestApplication
+{
+	public class TestClass
+	{
+		public TestClass(IEnumerable<int> args)
+		{
+			var local = args.ToReadOnlyCollection();
+		}
+	}
+}";
+			VerifyCSharpDiagnostic(validProgram);
+		}
+
+		[Test]
+		public void AssignLocalIsValid()
+		{
+			const string validProgram = c_preamble + @"
+namespace TestApplication
+{
+	public class TestClass
+	{
+		public TestClass(IEnumerable<int> args)
+		{
+			ReadOnlyCollection<int> local;
+			local = args.ToReadOnlyCollection();
+		}
+	}
+}";
+			VerifyCSharpDiagnostic(validProgram);
+		}
+
+		[Test]
+		public void AssignField()
+		{
+			const string program = c_preamble + @"
+namespace TestApplication
+{
+	public class TestClass
+	{
+		public TestClass(IEnumerable<int> args)
+		{
+			m_field = args.ToReadOnlyCollection();
+		}
+
+		ReadOnlyCollection<int> m_field;
+	}
+}";
+
+			var expected = new DiagnosticResult
+			{
+				Id = ToReadOnlyCollectionAnalyzer.DiagnosticId,
+				Message = "Avoid ToReadOnlyCollection in constructors.",
+				Severity = DiagnosticSeverity.Warning,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 20, 19) },
+			};
+
+			VerifyCSharpDiagnostic(program, expected);
+
+			const string fix = c_preamble + @"
+namespace TestApplication
+{
+	public class TestClass
+	{
+		public TestClass(IEnumerable<int> args)
+		{
+			m_field = args.ToList().AsReadOnly();
+		}
+
+		ReadOnlyCollection<int> m_field;
+	}
+}";
+
+			VerifyCSharpFix(program, fix, 0);
+		}
+
+		[Test]
+		public void AssignProperty()
+		{
+			const string program = c_preamble + @"
+namespace TestApplication
+{
+	public class TestClass
+	{
+		public TestClass(IEnumerable<int> args)
+		{
+			Property = args.ToReadOnlyCollection();
+		}
+
+		public ReadOnlyCollection<int> Property { get; }
+	}
+}";
+
+			var expected = new DiagnosticResult
+			{
+				Id = ToReadOnlyCollectionAnalyzer.DiagnosticId,
+				Message = "Avoid ToReadOnlyCollection in constructors.",
+				Severity = DiagnosticSeverity.Warning,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 20, 20) },
+			};
+
+			VerifyCSharpDiagnostic(program, expected);
+
+
+			const string fix = c_preamble + @"
+namespace TestApplication
+{
+	public class TestClass
+	{
+		public TestClass(IEnumerable<int> args)
+		{
+			Property = args.ToList().AsReadOnly();
+		}
+
+		public ReadOnlyCollection<int> Property { get; }
+	}
+}";
+
+			VerifyCSharpFix(program, fix, 0);
+		}
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new ToReadOnlyCollectionAnalyzer();
+
+		protected override CodeFixProvider GetCSharpCodeFixProvider() => new ToReadOnlyCollectionCodeFixProvider();
+
+		private const string c_preamble = @"using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Libronix.Utility;
+
+namespace Libronix.Utility
+{
+	public static class EnumerableUtility
+	{
+		public static ReadOnlyCollection<T> ToReadOnlyCollection<T>(this IEnumerable<T> seq) => throw new NotImplementedException();
+	}
+}
+";
+	}
+}


### PR DESCRIPTION
Analyzer and code fix for using `.ToReadOnlyCollection()` to assign a field or property in a constructor.