### PR TITLE
 Add analyzer to find available IWorkStates. 

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["editorconfig.editorconfig"]
+}

--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -12,6 +12,7 @@ or errors for existing code when the package is upgraded).
 * [minor] Add `FL0005`: detect `.ToReadOnlyCollection()` in constructors: [#17](https://github.com/Faithlife/FaithlifeAnalyzers/issues/17).
 * [minor] Add `FL0006`: detect `.OrderBy` without a `StringComparer`: [#23](https://github.com/Faithlife/FaithlifeAnalyzers/issues/23).
 * [minor] Add `FL0007`: detect `$` in interpolated strings: [#50](https://github.com/Faithlife/FaithlifeAnalyzers/issues/50).
+* [minor] Add `FL0008`: detect usages of `WorkState.None` and `WorkState.ToDo` when alternatives exist: [#4](https://github.com/Faithlife/FaithlifeAnalyzers/issues/4)
 
 ## Released
 

--- a/src/Faithlife.Analyzers/AvailableWorkStateAnalyzer.cs
+++ b/src/Faithlife.Analyzers/AvailableWorkStateAnalyzer.cs
@@ -1,0 +1,103 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Faithlife.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed class AvailableWorkStateAnalyzer : DiagnosticAnalyzer
+	{
+		public override void Initialize(AnalysisContext context)
+		{
+			context.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.SimpleMemberAccessExpression);
+		}
+
+		public const string DiagnosticId = "FL0008";
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(s_rule); } }
+
+		private static void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
+		{
+			var syntax = (MemberAccessExpressionSyntax)context.Node;
+
+			var iworkState = context.SemanticModel.Compilation.GetTypeByMetadataName("Libronix.Utility.Threading.IWorkState");
+			if (iworkState == null)
+				return;
+
+			var workStateClass = context.SemanticModel.Compilation.GetTypeByMetadataName("Libronix.Utility.Threading.WorkState");
+			if (workStateClass == null)
+				return;
+
+			var workStateNone = workStateClass.GetMembers("None");
+			if (workStateNone == null || workStateNone.Length != 1)
+				return;
+
+			var workStateToDo = workStateClass.GetMembers("ToDo");
+			if (workStateToDo == null || workStateToDo.Length != 1)
+				return;
+
+			var symbolInfo = context.SemanticModel.GetSymbolInfo(syntax.Expression);
+			if (symbolInfo.Symbol == null || !symbolInfo.Symbol.Equals(workStateClass))
+				return;
+
+			var memberSymbolInfo = context.SemanticModel.GetSymbolInfo(syntax.Name);
+			if (memberSymbolInfo.Symbol == null || (!memberSymbolInfo.Symbol.Equals(workStateNone[0]) && !memberSymbolInfo.Symbol.Equals(workStateToDo[0])))
+				return;
+
+			var containingMethod = syntax.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
+			if (containingMethod == null)
+				return;
+
+			var asyncAction = context.SemanticModel.Compilation.GetTypeByMetadataName("Libronix.Utility.Threading.AsyncAction");
+			if (asyncAction != null)
+			{
+				var ienumerable = context.SemanticModel.Compilation.GetTypeByMetadataName("System.Collections.Generic.IEnumerable`1");
+				var returnTypeSymbol = context.SemanticModel.GetSymbolInfo(containingMethod.ReturnType).Symbol as INamedTypeSymbol;
+				if (returnTypeSymbol != null && returnTypeSymbol.ConstructedFrom != null && returnTypeSymbol.ConstructedFrom.Equals(ienumerable) &&
+					returnTypeSymbol.TypeArguments[0].Equals(asyncAction))
+				{
+					context.ReportDiagnostic(Diagnostic.Create(s_rule, syntax.GetLocation()));
+					return;
+				}
+			}
+
+			var cancellationToken = context.SemanticModel.Compilation.GetTypeByMetadataName("System.Threading.CancellationToken");
+			var asyncMethodContext = context.SemanticModel.Compilation.GetTypeByMetadataName("Libronix.Utility.Threading.AsyncMethodContext");
+			var hasWorkStateParameters = containingMethod.ParameterList.Parameters.Any(parameter =>
+			{
+				var parameterSymbolInfo = context.SemanticModel.GetSymbolInfo(parameter.Type);
+				if (parameterSymbolInfo.Symbol is null)
+					return false;
+
+				if (symbolInfo.Symbol.Equals(iworkState))
+					return true;
+
+				var namedTypeSymbol = parameterSymbolInfo.Symbol as INamedTypeSymbol;
+				if (namedTypeSymbol is null)
+					return false;
+
+				if (namedTypeSymbol.Equals(iworkState) || namedTypeSymbol.Equals(cancellationToken) || namedTypeSymbol.Equals(asyncMethodContext))
+					return true;
+
+				return namedTypeSymbol.AllInterfaces.Any(x => x.Equals(iworkState));
+			});
+
+			if (!hasWorkStateParameters)
+				return;
+
+			context.ReportDiagnostic(Diagnostic.Create(s_rule, syntax.GetLocation()));
+		}
+
+		static readonly DiagnosticDescriptor s_rule = new DiagnosticDescriptor(
+			id: DiagnosticId,
+			title: "WorkState.None and WorkState.ToDo Usage",
+			messageFormat: "WorkState.None and WorkState.ToDo must not be used when an IWorkState is available.",
+			category: "Usage",
+			defaultSeverity: DiagnosticSeverity.Error,
+			isEnabledByDefault: true,
+			helpLinkUri: "https://github.com/Faithlife/FaithlifeAnalyzers/wiki/FL0008");
+	}
+}

--- a/src/Faithlife.Analyzers/AvailableWorkStateCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/AvailableWorkStateCodeFixProvider.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Simplification;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Faithlife.Analyzers
+{
+	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CurrentAsyncWorkItemCodeFixProvider)), Shared]
+	public class AvailableWorkStateCodeFixProvider : CodeFixProvider
+	{
+		public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(AvailableWorkStateAnalyzer.DiagnosticId);
+
+		public sealed override FixAllProvider GetFixAllProvider() => null;
+
+		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		{
+			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+			var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+			var iworkState = semanticModel.Compilation.GetTypeByMetadataName("Libronix.Utility.Threading.IWorkState");
+			if (iworkState is null)
+				return;
+
+			var diagnostic = context.Diagnostics.First();
+			var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+			var diagnosticNode = root.FindNode(diagnosticSpan);
+			var memberAccess = diagnosticNode.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>().FirstOrDefault();
+			if (memberAccess is null)
+				return;
+
+			var containingMethod = diagnosticNode.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
+			if (containingMethod is null)
+				return;
+
+			var asyncAction = semanticModel.Compilation.GetTypeByMetadataName("Libronix.Utility.Threading.AsyncAction");
+			var asyncMethodContext = semanticModel.Compilation.GetTypeByMetadataName("Libronix.Utility.Threading.AsyncMethodContext");
+			if (asyncAction != null)
+			{
+				var ienumerable = semanticModel.Compilation.GetTypeByMetadataName("System.Collections.Generic.IEnumerable`1");
+				var returnTypeSymbol = semanticModel.GetSymbolInfo(containingMethod.ReturnType).Symbol as INamedTypeSymbol;
+				if (returnTypeSymbol != null && returnTypeSymbol.ConstructedFrom != null && returnTypeSymbol.ConstructedFrom.Equals(ienumerable) &&
+					returnTypeSymbol.TypeArguments[0].Equals(asyncAction))
+				{
+					context.RegisterCodeFix(
+						CodeAction.Create(
+							title: $"Use AsyncWorkItem.Current",
+							createChangedDocument: token => ReplaceValueAsync(context.Document, memberAccess, s_currentWorkItemExpression, token),
+							$"use-asyncworkitem-current"),
+						diagnostic);
+				}
+			}
+
+			var cancellationToken = semanticModel.Compilation.GetTypeByMetadataName("System.Threading.CancellationToken");
+			foreach (var parameter in containingMethod.ParameterList.Parameters)
+			{
+				var symbolInfo = semanticModel.GetSymbolInfo(parameter.Type);
+				if (symbolInfo.Symbol is null)
+					continue;
+
+				if (symbolInfo.Symbol.Equals(iworkState) || (symbolInfo.Symbol is INamedTypeSymbol namedTypeSymbol && namedTypeSymbol.AllInterfaces.Any(x => x.Equals(iworkState))))
+				{
+					context.RegisterCodeFix(
+						CodeAction.Create(
+							title: $"Use '{parameter.Identifier.Text}' parameter of {containingMethod.Identifier.Text}",
+							createChangedDocument: token => ReplaceValueAsync(context.Document, memberAccess, IdentifierName(parameter.Identifier), token),
+							$"use-{parameter.Identifier.Text}"),
+						diagnostic);
+				}
+				else if (symbolInfo.Symbol.Equals(cancellationToken))
+				{
+					context.RegisterCodeFix(
+						CodeAction.Create(
+							title: $"Use '{parameter.Identifier.Text}' parameter of {containingMethod.Identifier.Text}",
+							createChangedDocument: token => ReplaceValueAsync(
+								context.Document,
+								memberAccess,
+								ReplaceIdentifier(s_fromCancellationTokenExpression, "token", IdentifierName(parameter.Identifier)),
+								token),
+							$"use-{parameter.Identifier.Text}"),
+						diagnostic);
+				}
+				else if (symbolInfo.Symbol.Equals(asyncMethodContext))
+				{
+					context.RegisterCodeFix(
+						CodeAction.Create(
+							title: $"Use '{parameter.Identifier.Text}' parameter of {containingMethod.Identifier.Text}",
+							createChangedDocument: token => ReplaceValueAsync(
+								context.Document,
+								memberAccess,
+								ReplaceIdentifier(s_contextWorkStateExpression, "asyncMethodContext", IdentifierName(parameter.Identifier)),
+								token),
+							$"use-{parameter.Identifier.Text}"),
+						diagnostic);
+				}
+			}
+		}
+
+		private static async Task<Document> ReplaceValueAsync(Document document, MemberAccessExpressionSyntax memberAccess, ExpressionSyntax replacementNode, CancellationToken cancellationToken)
+		{
+			var root = (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false))
+				.ReplaceNode(memberAccess, replacementNode);
+
+			return await Simplifier.ReduceAsync(document.WithSyntaxRoot(root), cancellationToken: cancellationToken).ConfigureAwait(false);
+		}
+
+		private static NameSyntax ParseQualifiedName(string qualifiedName) =>
+			qualifiedName
+				.Split('.')
+				.Select(IdentifierName)
+				.Cast<NameSyntax>()
+				.Aggregate((left, right) => QualifiedName(left, (IdentifierNameSyntax)right));
+
+		private static ExpressionSyntax ReplaceIdentifier(ExpressionSyntax expression, string originalIdentifierName, ExpressionSyntax replacement)
+		{
+			var targetNodes = expression.DescendantNodes()
+				.OfType<IdentifierNameSyntax>()
+				.Where(x => x.Identifier.Text == originalIdentifierName)
+				.ToList();
+
+			if (targetNodes.Count == 0)
+				throw new InvalidOperationException($"The identifier {originalIdentifierName} was not found in the expression.");
+
+			return expression.ReplaceNodes(targetNodes, (x, y) => replacement);
+		}
+
+		static readonly ExpressionSyntax s_currentWorkItemExpression = ReplaceIdentifier(
+			ParseExpression("AsyncWorkItem.Current"),
+			"AsyncWorkItem",
+			ParseQualifiedName("Libronix.Utility.Threading.AsyncWorkItem").WithAdditionalAnnotations(Simplifier.Annotation));
+
+		static readonly ExpressionSyntax s_fromCancellationTokenExpression = ReplaceIdentifier(
+			ParseExpression("WorkState.FromCancellationToken(token)"),
+			"WorkState",
+			ParseQualifiedName("Libronix.Utility.Threading.WorkState").WithAdditionalAnnotations(Simplifier.Annotation));
+
+		static readonly ExpressionSyntax s_contextWorkStateExpression = ParseExpression("asyncMethodContext.WorkState");
+	}
+}

--- a/tests/Faithlife.Analyzers.Tests/AvailableWorkStateTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/AvailableWorkStateTests.cs
@@ -1,0 +1,390 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Framework;
+
+namespace Faithlife.Analyzers.Tests
+{
+	[TestFixture]
+	public class AvailableWorkStateTests : CodeFixVerifier
+	{
+		[TestCase("None")]
+		[TestCase("ToDo")]
+		public void ValidUsage(string property)
+		{
+			string validProgram = preamble + @"
+namespace TestApplication
+{
+	internal static class TestClass
+	{
+		public static void UtilityMethod()
+		{
+			HelperMethod(WorkState." + property + @");
+		}
+
+		private static void HelperMethod(IWorkState workState)
+		{
+		}
+	}
+}";
+			VerifyCSharpDiagnostic(validProgram);
+		}
+
+		[TestCase("None")]
+		[TestCase("ToDo")]
+		public void IgnoredCurrentWorkState(string property)
+		{
+			string brokenProgram = preamble + @"
+namespace TestApplication
+{
+	internal static class TestClass
+	{
+		public static IEnumerable<AsyncAction> Method()
+		{
+			HelperMethod(WorkState." + property + @");
+			yield break;
+		}
+
+		private static void HelperMethod(IWorkState workState)
+		{
+		}
+	}
+}
+";
+
+			var expected = new DiagnosticResult
+			{
+				Id = AvailableWorkStateAnalyzer.DiagnosticId,
+				Message = "WorkState.None and WorkState.ToDo must not be used when an IWorkState is available.",
+				Severity = DiagnosticSeverity.Error,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 7, 17) },
+			};
+
+			VerifyCSharpDiagnostic(brokenProgram, expected);
+
+			const string firstFix = preamble + @"
+namespace TestApplication
+{
+	internal static class TestClass
+	{
+		public static IEnumerable<AsyncAction> Method()
+		{
+			HelperMethod(AsyncWorkItem.Current);
+			yield break;
+		}
+
+		private static void HelperMethod(IWorkState workState)
+		{
+		}
+	}
+}
+";
+
+			VerifyCSharpFix(brokenProgram, firstFix, 0);
+		}
+
+		[TestCase("None")]
+		[TestCase("ToDo")]
+		public void IgnoredIWorkState(string property)
+		{
+			string brokenProgram = preamble + @"
+namespace TestApplication
+{
+	internal static class TestClass
+	{
+		public static void Method(IWorkState ignored)
+		{
+			HelperMethod(WorkState." + property + @");
+		}
+
+		private static void HelperMethod(IWorkState workState)
+		{
+		}
+	}
+}
+";
+
+			var expected = new DiagnosticResult
+			{
+				Id = AvailableWorkStateAnalyzer.DiagnosticId,
+				Message = "WorkState.None and WorkState.ToDo must not be used when an IWorkState is available.",
+				Severity = DiagnosticSeverity.Error,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 7, 17) },
+			};
+
+			VerifyCSharpDiagnostic(brokenProgram, expected);
+
+			const string firstFix = preamble + @"
+namespace TestApplication
+{
+	internal static class TestClass
+	{
+		public static void Method(IWorkState ignored)
+		{
+			HelperMethod(ignored);
+		}
+
+		private static void HelperMethod(IWorkState workState)
+		{
+		}
+	}
+}
+";
+
+			VerifyCSharpFix(brokenProgram, firstFix, 0);
+		}
+
+		[TestCase("None")]
+		[TestCase("ToDo")]
+		public void IgnoredConcreteWorkState(string property)
+		{
+			string brokenProgram = preamble + @"
+namespace TestApplication
+{
+	internal static class TestClass
+	{
+		public static void Method(ConcreteWorkState ignored)
+		{
+			HelperMethod(WorkState." + property + @");
+		}
+
+		private static void HelperMethod(IWorkState workState)
+		{
+		}
+	}
+}
+";
+
+			var expected = new DiagnosticResult
+			{
+				Id = AvailableWorkStateAnalyzer.DiagnosticId,
+				Message = "WorkState.None and WorkState.ToDo must not be used when an IWorkState is available.",
+				Severity = DiagnosticSeverity.Error,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 7, 17) },
+			};
+
+			VerifyCSharpDiagnostic(brokenProgram, expected);
+
+			const string firstFix = preamble + @"
+namespace TestApplication
+{
+	internal static class TestClass
+	{
+		public static void Method(ConcreteWorkState ignored)
+		{
+			HelperMethod(ignored);
+		}
+
+		private static void HelperMethod(IWorkState workState)
+		{
+		}
+	}
+}
+";
+
+			VerifyCSharpFix(brokenProgram, firstFix, 0);
+		}
+
+		[TestCase("None")]
+		[TestCase("ToDo")]
+		public void IgnoredCancellationToken(string property)
+		{
+			string brokenProgram = preamble + @"
+namespace TestApplication
+{
+	internal static class TestClass
+	{
+		public static void Method(CancellationToken ignored)
+		{
+			HelperMethod(WorkState." + property + @");
+		}
+
+		private static void HelperMethod(IWorkState workState)
+		{
+		}
+	}
+}
+";
+
+			var expected = new DiagnosticResult
+			{
+				Id = AvailableWorkStateAnalyzer.DiagnosticId,
+				Message = "WorkState.None and WorkState.ToDo must not be used when an IWorkState is available.",
+				Severity = DiagnosticSeverity.Error,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 7, 17) },
+			};
+
+			VerifyCSharpDiagnostic(brokenProgram, expected);
+
+			const string firstFix = preamble + @"
+namespace TestApplication
+{
+	internal static class TestClass
+	{
+		public static void Method(CancellationToken ignored)
+		{
+			HelperMethod(WorkState.FromCancellationToken(ignored));
+		}
+
+		private static void HelperMethod(IWorkState workState)
+		{
+		}
+	}
+}
+";
+
+			VerifyCSharpFix(brokenProgram, firstFix, 0);
+		}
+
+		[TestCase("None")]
+		[TestCase("ToDo")]
+		public void IgnoredAsyncMethodContext(string property)
+		{
+			string brokenProgram = preamble + @"
+namespace TestApplication
+{
+	internal static class TestClass
+	{
+		public static void Method(AsyncMethodContext ignored)
+		{
+			HelperMethod(WorkState." + property + @");
+		}
+
+		private static void HelperMethod(IWorkState workState)
+		{
+		}
+	}
+}
+";
+
+			var expected = new DiagnosticResult
+			{
+				Id = AvailableWorkStateAnalyzer.DiagnosticId,
+				Message = "WorkState.None and WorkState.ToDo must not be used when an IWorkState is available.",
+				Severity = DiagnosticSeverity.Error,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 7, 17) },
+			};
+
+			VerifyCSharpDiagnostic(brokenProgram, expected);
+
+			const string firstFix = preamble + @"
+namespace TestApplication
+{
+	internal static class TestClass
+	{
+		public static void Method(AsyncMethodContext ignored)
+		{
+			HelperMethod(ignored.WorkState);
+		}
+
+		private static void HelperMethod(IWorkState workState)
+		{
+		}
+	}
+}
+";
+
+			VerifyCSharpFix(brokenProgram, firstFix, 0);
+		}
+
+		[TestCase("None")]
+		[TestCase("ToDo")]
+		public void MultipleOptions(string property)
+		{
+			string CreateProgramWithParameter(string expectedParameter) =>
+				preamble + @"
+namespace TestApplication
+{
+	internal static class TestClass
+	{
+		public static IEnumerable<AsyncAction> Method(IWorkState ignored1, ConcreteWorkState ignored2, CancellationToken ignored3, AsyncMethodContext ignored4)
+		{
+			HelperMethod(" + expectedParameter + @");
+			yield break;
+		}
+
+		private static void HelperMethod(IWorkState workState)
+		{
+		}
+	}
+}
+";
+
+			string brokenProgram = CreateProgramWithParameter($"WorkState.{property}");
+
+			var expected = new DiagnosticResult
+			{
+				Id = AvailableWorkStateAnalyzer.DiagnosticId,
+				Message = "WorkState.None and WorkState.ToDo must not be used when an IWorkState is available.",
+				Severity = DiagnosticSeverity.Error,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 7, 17) },
+			};
+
+			VerifyCSharpDiagnostic(brokenProgram, expected);
+			VerifyCSharpFixes(
+				brokenProgram,
+				CreateProgramWithParameter("AsyncWorkItem.Current"),
+				CreateProgramWithParameter("ignored1"),
+				CreateProgramWithParameter("ignored2"),
+				CreateProgramWithParameter("WorkState.FromCancellationToken(ignored3)"),
+				CreateProgramWithParameter("ignored4.WorkState"));
+		}
+
+		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		{
+			return new AvailableWorkStateCodeFixProvider();
+		}
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+		{
+			return new AvailableWorkStateAnalyzer();
+		}
+
+		private void VerifyCSharpFixes(string brokenProgram, params string[] fixedPrograms)
+		{
+			for (var currentFix = 0; currentFix < fixedPrograms.Length; currentFix++)
+				VerifyCSharpFix(brokenProgram, fixedPrograms[currentFix], currentFix);
+		}
+
+		private const string preamble = @"using System;
+using System.Collections.Generic;
+using System.Threading;
+using Libronix.Utility.Threading;
+
+namespace Libronix.Utility.Threading
+{
+	public sealed class AsyncAction {}
+
+	public interface IWorkState
+	{
+		bool Canceled { get; }
+	}
+
+	public sealed class AsyncWorkItem : IWorkState
+	{
+		public static AsyncWorkItem Current => throw new NotImplementedException();
+		public bool Canceled => false;
+	}
+
+	public sealed class AsyncMethodContext
+	{
+		public IWorkState WorkState => throw new NotImplementedException();
+	}
+
+	public sealed class ConcreteWorkState : IWorkState
+	{
+		public bool Canceled => false;
+	}
+
+	public static class WorkState
+	{
+		public static IWorkState FromCancellationToken(CancellationToken token) => throw new NotImplementedException();
+		public static IWorkState None => throw new NotImplementedException();
+		public static IWorkState ToDo => throw new NotImplementedException();
+	}
+}
+";
+
+		static readonly int c_preambleLength = preamble.Split('\n').Length;
+	}
+}


### PR DESCRIPTION
Resolves #4.

Of particular note in this PR is a new mechanism for building up `SyntaxExpressions`: rather than create a huge tree of `SyntaxFactory` calls, I start with a call to `ParseExpression` and then replace identifiers, as necessary.

I also created a helper to create `QualifiedNames` that splits a fully qualified name on `.`.

I think that both of these improve the readability of the fix providers—and that their value will become more apparent with more complex expressions—but I can go back to something more standard if others hate it.