### PR TITLE
Add fixer for the most common `IfNotNull` invocation patterns.

### DIFF
--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -13,6 +13,8 @@ or errors for existing code when the package is upgraded).
 * [minor] Add `FL0006`: detect `.OrderBy` without a `StringComparer`: [#23](https://github.com/Faithlife/FaithlifeAnalyzers/issues/23).
 * [minor] Add `FL0007`: detect `$` in interpolated strings: [#50](https://github.com/Faithlife/FaithlifeAnalyzers/issues/50).
 * [minor] Add `FL0008`: detect usages of `WorkState.None` and `WorkState.ToDo` when alternatives exist: [#4](https://github.com/Faithlife/FaithlifeAnalyzers/issues/4)
+* [minor] Add `FL0009`: prefer `""` over `string.Empty`: [#7](https://github.com/Faithlife/FaithlifeAnalyzers/issues/7)
+* [minor] Add `FL0010`: discourage use of `IfNotNull`: [#13](https://github.com/Faithlife/FaithlifeAnalyzers/issues/13)
 
 ## Released
 

--- a/src/Faithlife.Analyzers/CurrentAsyncWorkItemCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/CurrentAsyncWorkItemCodeFixProvider.cs
@@ -93,18 +93,11 @@ namespace Faithlife.Analyzers
 				.ReplaceNode(containingMethod, containingMethod
 					.ReplaceNode(memberAccess, IdentifierName(parameterIdentifier))
 					.AddParameterListParameters(Parameter(parameterIdentifier)
-						.WithType(s_iworkStateTypeName)
-						.WithAdditionalAnnotations(Simplifier.Annotation)));
+						.WithType(s_iworkStateTypeName)));
 
 			return await Simplifier.ReduceAsync(document.WithSyntaxRoot(root), cancellationToken: cancellationToken).ConfigureAwait(false);
 		}
 
-		static readonly QualifiedNameSyntax s_iworkStateTypeName = QualifiedName(
-			QualifiedName(
-				QualifiedName(
-					IdentifierName("Libronix"),
-					IdentifierName("Utility")),
-				IdentifierName("Threading")),
-			IdentifierName("IWorkState"));
+		private static readonly TypeSyntax s_iworkStateTypeName = SyntaxUtility.ParseSimplifiableTypeName("Libronix.Utility.Threading.IWorkState");
 	}
 }

--- a/src/Faithlife.Analyzers/IfNotNullAnalyzer.cs
+++ b/src/Faithlife.Analyzers/IfNotNullAnalyzer.cs
@@ -1,0 +1,55 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Faithlife.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed class IfNotNullAnalyzer : DiagnosticAnalyzer
+	{
+		public override void Initialize(AnalysisContext context)
+		{
+			context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
+			{
+				var ifNotNullExtensionMethodType = compilationStartAnalysisContext.Compilation.GetTypeByMetadataName("Libronix.Utility.IfNotNull.IfNotNullExtensionMethod");
+				if (ifNotNullExtensionMethodType == null)
+					return;
+
+				var ifNotNullMethods = ifNotNullExtensionMethodType.GetMembers("IfNotNull");
+				if (ifNotNullMethods.Length == 0)
+					return;
+
+				compilationStartAnalysisContext.RegisterSyntaxNodeAction(c => AnalyzeSyntax(c, ifNotNullMethods), SyntaxKind.InvocationExpression);
+			});
+		}
+
+		public const string DiagnosticId = "FL0010";
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
+
+		private static void AnalyzeSyntax(SyntaxNodeAnalysisContext context, ImmutableArray<ISymbol> ifNotNullMethods)
+		{
+			var syntax = (InvocationExpressionSyntax) context.Node;
+
+			var methodSymbol = context.SemanticModel.GetSymbolInfo(syntax.Expression).Symbol as IMethodSymbol;
+			if (methodSymbol == null ||
+				(methodSymbol.ReducedFrom == null && methodSymbol.ConstructedFrom == null) ||
+				!ifNotNullMethods.Any(x => x.Equals(methodSymbol.ReducedFrom) || (x.Equals(methodSymbol.ConstructedFrom))))
+				return;
+
+			context.ReportDiagnostic(Diagnostic.Create(s_rule, syntax.GetLocation()));
+		}
+
+		private static readonly DiagnosticDescriptor s_rule = new DiagnosticDescriptor(
+			id: DiagnosticId,
+			title: "IfNotNull deprecation",
+			messageFormat: "Prefer modern language features over IfNotNull usage.",
+			category: "Usage",
+			defaultSeverity: DiagnosticSeverity.Info,
+			isEnabledByDefault: true,
+			helpLinkUri: $"https://github.com/Faithlife/FaithlifeAnalyzers/wiki/{DiagnosticId}");
+	}
+}

--- a/src/Faithlife.Analyzers/IfNotNullCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/IfNotNullCodeFixProvider.cs
@@ -1,0 +1,434 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Simplification;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Faithlife.Analyzers
+{
+	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(IfNotNullCodeFixProvider)), Shared]
+	public sealed class IfNotNullCodeFixProvider : CodeFixProvider
+	{
+		public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(IfNotNullAnalyzer.DiagnosticId);
+
+		public sealed override FixAllProvider GetFixAllProvider() => IfNotNullFixAllProvider.Instance;
+
+		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		{
+			var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+
+			var ifNotNullExtensionMethodType = semanticModel.Compilation.GetTypeByMetadataName("Libronix.Utility.IfNotNull.IfNotNullExtensionMethod");
+			if (ifNotNullExtensionMethodType is null)
+				return;
+
+			var ifNotNullMethods = ifNotNullExtensionMethodType.GetMembers("IfNotNull");
+			if (ifNotNullMethods.Length == 0)
+				return;
+
+			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+			var diagnostic = context.Diagnostics.First();
+			var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+			var diagnosticNode = root.FindNode(diagnosticSpan);
+
+			var ifNotNullInvocation = diagnosticNode.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+			if (ifNotNullInvocation is null)
+				return;
+
+			var methodSymbol = semanticModel.GetSymbolInfo(ifNotNullInvocation).Symbol as IMethodSymbol;
+
+			// There is a family of void IfNotNull method overloads that only have a single type argument.
+			// The handling of these is completely different; I supsect that usages are vanishingly rare, so
+			// for now, just bail on these.
+			if (methodSymbol.Arity != 2)
+				return;
+
+			// The location of each of the arguments changes based on whether the method is invoked as an extension method.
+			var targetExpression = methodSymbol.IsStatic ?
+				ifNotNullInvocation.ArgumentList.Arguments[0].Expression :
+				((MemberAccessExpressionSyntax) ifNotNullInvocation.Expression).Expression;
+
+			var delegateExpression = methodSymbol.IsStatic ?
+				ifNotNullInvocation.ArgumentList.Arguments[1].Expression :
+				ifNotNullInvocation.ArgumentList.Arguments[0].Expression;
+
+			var defaultArgumentIndex = methodSymbol.IsStatic ? 2 : 1;
+			var defaultValueExpression = ifNotNullInvocation.ArgumentList.Arguments.Count > defaultArgumentIndex ?
+				ifNotNullInvocation.ArgumentList.Arguments[defaultArgumentIndex].Expression :
+				default;
+
+			var outputTypeArgument = methodSymbol.TypeArguments[1];
+
+			// Handle default value generators.
+			if (methodSymbol.Parameters.Length > defaultArgumentIndex && methodSymbol.Parameters[defaultArgumentIndex].Type != outputTypeArgument)
+			{
+				if (defaultValueExpression is LambdaExpressionSyntax lambda)
+				{
+					// I can't imagine that anyone is using IfNotNull in async contexts, but
+					// better to be safe than sorry.
+					if (!lambda.AsyncKeyword.IsKind(SyntaxKind.None))
+						return;
+
+					// Only handle expression-bodied lambdas. A lambda with a block body would need to
+					// be converted to a local method, and that's probably too much effort to bother with
+					// relative to the number of them I would expect to see.
+					if (!(lambda.Body is ExpressionSyntax defaultLambdaExpression))
+						return;
+
+					// The point of allowing lambas to be specified was so that the value could be lazily evaluated.
+					// Now that we'll be using language constructs that are lazily evaluated, so we can just unwrap
+					// the lambda.
+					defaultValueExpression = defaultLambdaExpression;
+				}
+				else if (defaultValueExpression is AnonymousFunctionExpressionSyntax)
+				{
+					// If it's not a lambda, but it *is* an anonymous function, then it's a C# 2.0-style
+					// anonymous delegate. Who would do such a thing?
+					return;
+				}
+				else
+				{
+					// If it's not a lambda and it's not any other kind of anonymous function,
+					// then it must be a reference to a delegate. We can transform this into
+					// an invocation of the delegate.
+					defaultValueExpression = InvocationExpression(defaultValueExpression);
+				}
+			}
+
+			var outputTypeIsNullable = outputTypeArgument.IsReferenceType ||
+				((outputTypeArgument as INamedTypeSymbol)?.ConstructedFrom?.SpecialType.HasFlag(SpecialType.System_Nullable_T) ?? false);
+
+			// Explicitly supplying default(SomeType) or null is identical to not supplying anything.
+			// However, the presence of a defaultValueExpression will prevent us from using
+			// the most concise formulation for reference types. Clearing this out allows the other
+			// optimizations to take place.
+			//
+			// On the other hand, value types always need a default value expression. This is because
+			// the null-conditional operator always forces a result to be nullable (either a reference type
+			// or Nullable<T>), while IfNotNull does not. In order to create a compatible replacement,
+			// a default value expression must be used in order to ensure that the resulting expression
+			// evaluates to the correct type.
+			if (outputTypeIsNullable &&
+				(defaultValueExpression is DefaultExpressionSyntax ||
+			 		(defaultValueExpression is LiteralExpressionSyntax defaultLiteral && defaultLiteral.IsKind(SyntaxKind.NullLiteralExpression))))
+			{
+				defaultValueExpression = null;
+			}
+			else if (defaultValueExpression is null && !outputTypeIsNullable)
+			{
+				if (!outputTypeArgument.CanBeReferencedByName)
+					return;
+
+				defaultValueExpression = DefaultExpression(GetTypeSyntax(outputTypeArgument));
+			}
+
+			var lambdaExpression = delegateExpression as LambdaExpressionSyntax;
+			if (lambdaExpression is null)
+			{
+				// Don't even bother trying to handle C# 2.0-style anonymous delegates.
+				if (delegateExpression is AnonymousFunctionExpressionSyntax)
+					return;
+
+				// If this isn't an anonymous function, then it must be a reference to a
+				// delegate. We can transform this into a lambda expression that invokes
+				// the delegate.
+
+				var parameterIdentifier = Identifier("value");
+				lambdaExpression = SimpleLambdaExpression(
+					Parameter(parameterIdentifier),
+					InvocationExpression(
+						SimplifiableParentheses(delegateExpression),
+						ArgumentList(
+							SingletonSeparatedList(
+								Argument(
+									IdentifierName(parameterIdentifier))))));
+			}
+			else if (!lambdaExpression.AsyncKeyword.IsKind(SyntaxKind.None))
+			{
+				return;
+			}
+
+			var parameterList = GetLambdaParameters(lambdaExpression);
+			if (parameterList.Length != 1)
+				return;
+
+			var lambdaExpressionBody = lambdaExpression.Body as ExpressionSyntax;
+			// To properly handle block-bodied lambda expressions, we'll need to hoist
+			// the body of the lambda to a local function and call it. For now, skip this.
+			if (lambdaExpressionBody is null)
+				return;
+
+			// There are several factors that might prohibit us from using the conditional access operator.
+			// If we discover any of them, we'll mark this as false and fall back to this pattern:
+			// target is InferredType foo ? expression(foo) : defaultValue
+			var canUseConditionalOperator = true;
+
+			var lambdaParameterIdentifier = parameterList[0].Identifier;
+
+			if (lambdaExpressionBody.DescendantNodes()
+				.OfType<IdentifierNameSyntax>()
+				.Where(x => AreEquivalent(x.Identifier, lambdaParameterIdentifier))
+				.Take(2)
+				.Count() == 2)
+			{
+				canUseConditionalOperator = false;
+			}
+
+			// This one is a bit more subtle: a default expression will *usually* prevent us
+			// from using the conditional access operator because the default should only
+			// be used if the *target* is null, and using a null-coalescing operator might
+			// cause the default to be used if the expression results in null.
+
+			// The one exception to this is that if the TOutput argument is a value type:
+			// in this case, the conditional access operator will only evaluate to null if the
+			// target is null. This means that we can safely append a null-coalescing operator
+			// to get the desired value.
+			if (defaultValueExpression != null && outputTypeIsNullable)
+				canUseConditionalOperator = false;
+
+			// The conditional access operator does not work for delegate invocations, so
+			// this case needs to be tweaked a bit. A lambda in the form
+			//
+			// x => x(argument)
+			//
+			// should be transformed to
+			//
+			// x => x.Invoke(argument)
+			//
+			// At which point, the remaining portion of the method will be able to handle
+			// it appropriately.
+			if (canUseConditionalOperator &&
+				lambdaExpressionBody is InvocationExpressionSyntax toplevelInvocation &&
+				toplevelInvocation.Expression is IdentifierNameSyntax toplevelIdentifier &&
+				AreEquivalent(toplevelIdentifier.Identifier, lambdaParameterIdentifier))
+			{
+				lambdaExpressionBody = InvocationExpression(
+					ReplaceIdentifier(ParseExpression("target.Invoke"), "target", IdentifierName(lambdaParameterIdentifier)),
+					toplevelInvocation.ArgumentList);
+			}
+
+			// Some usages of IfNotNull explicitly cast the result to Nullable<T>, which means
+			// they can use the null-conditional operator without the cast or a null-conditional operator.
+			var mainLambdaExpressionBody = lambdaExpressionBody;
+			if (outputTypeIsNullable && !outputTypeArgument.IsReferenceType)
+			{
+				if (lambdaExpressionBody is CastExpressionSyntax cast)
+					mainLambdaExpressionBody = cast.Expression;
+				else if (lambdaExpressionBody is BinaryExpressionSyntax binaryExpression && binaryExpression.OperatorToken.IsKind(SyntaxKind.AsKeyword))
+					mainLambdaExpressionBody = binaryExpression.Left;
+			}
+
+			if (canUseConditionalOperator && GetLeftmostDescendant(mainLambdaExpressionBody) is IdentifierNameSyntax leftmostExpression)
+			{
+				if (AreEquivalent(leftmostExpression.Identifier, lambdaParameterIdentifier))
+				{
+					ConditionalAccessExpressionSyntax conditionalAccess;
+					if (leftmostExpression.Parent is MemberAccessExpressionSyntax leftMostMemberAccess)
+					{
+						conditionalAccess = ConditionalAccessExpression(
+							targetExpression,
+							mainLambdaExpressionBody.ReplaceNode(
+								leftMostMemberAccess,
+								MemberBindingExpression(leftMostMemberAccess.Name)));
+					}
+					else if (leftmostExpression.Parent is ElementAccessExpressionSyntax leftmostElementAccess)
+					{
+						conditionalAccess = ConditionalAccessExpression(
+							targetExpression,
+							mainLambdaExpressionBody.ReplaceNode(
+								leftmostElementAccess,
+								ElementBindingExpression(leftmostElementAccess.ArgumentList)));
+					}
+					else
+					{
+						conditionalAccess = default;
+					}
+
+					if (conditionalAccess != null)
+					{
+						ExpressionSyntax finalExpression = conditionalAccess;
+						if (defaultValueExpression != null)
+						{
+							finalExpression = ReplaceIdentifiers("fixedExpression ?? defaultExpression",
+								("fixedExpression", finalExpression),
+								("defaultExpression", defaultValueExpression));
+						}
+
+						context.RegisterCodeFix(
+							CodeAction.Create(
+								title: "Use conditional access operator",
+								createChangedDocument: token => ReplaceValueAsync(
+									context.Document,
+									ifNotNullInvocation,
+									SimplifiableParentheses(finalExpression),
+									token),
+								c_fixName),
+							diagnostic);
+
+						return;
+					}
+				}
+			}
+
+			if (!methodSymbol.TypeArguments[0].CanBeReferencedByName)
+				return;
+
+			// It's possible that hoisting the lambda's declaration into the parent context will cause naming conflicts.
+			// When this happens, we'll generate a new name that is unique to the context.
+			var originalName = lambdaParameterIdentifier.Text;
+			var hoistableIdentifier = SyntaxUtility.GetHoistableIdentifier(originalName, ifNotNullInvocation, parameterList[0]);
+			if (!AreEquivalent(lambdaParameterIdentifier, hoistableIdentifier))
+				lambdaExpressionBody = ReplaceIdentifier(lambdaExpressionBody, originalName, IdentifierName(hoistableIdentifier));
+
+			ExpressionSyntax replacementTarget;
+			ExpressionSyntax replacementExpression;
+
+			if (defaultValueExpression is null &&
+				ifNotNullInvocation.Parent is BinaryExpressionSyntax parentExpression &&
+				parentExpression.IsKind(SyntaxKind.CoalesceExpression) &&
+				parentExpression.Left == ifNotNullInvocation &&
+				(lambdaExpressionBody is AnonymousObjectCreationExpressionSyntax || lambdaExpressionBody is ObjectCreationExpressionSyntax))
+			{
+				// If we're certain that the lambda will return a non-null value (which is definitely the case with object creation expressions),
+				// then we can attempt to replace a slightly larger block of code. This allows expressions involving anonymous types to work
+				// in a few more contexts.
+				replacementTarget = parentExpression;
+				replacementExpression = ConditionalExpression(
+					IsPatternExpression(targetExpression, DeclarationPattern(GetTypeSyntax(methodSymbol.TypeArguments[0]), SingleVariableDesignation(hoistableIdentifier))),
+					lambdaExpressionBody,
+					parentExpression.Right);
+			}
+			else if (defaultValueExpression is object || outputTypeArgument.CanBeReferencedByName)
+			{
+				replacementTarget = ifNotNullInvocation;
+				replacementExpression = ConditionalExpression(
+					IsPatternExpression(targetExpression, DeclarationPattern(GetTypeSyntax(methodSymbol.TypeArguments[0]), SingleVariableDesignation(hoistableIdentifier))),
+					SimplifiableParentheses(lambdaExpressionBody),
+					defaultValueExpression ?? DefaultExpression(GetTypeSyntax(outputTypeArgument)));
+			}
+			else
+			{
+				// If we can't name the type, we can't create a proper default expression, so there's nothing left that can be done.
+				return;
+			}
+
+			context.RegisterCodeFix(
+				CodeAction.Create(
+					title: "Use pattern matching",
+					createChangedDocument: token => ReplaceValueAsync(
+						context.Document,
+						replacementTarget,
+						SimplifiableParentheses(replacementExpression),
+						token),
+					c_fixName),
+				diagnostic);
+		}
+
+		private static ImmutableArray<ParameterSyntax> GetLambdaParameters(LambdaExpressionSyntax lambda)
+		{
+			if (lambda is SimpleLambdaExpressionSyntax simpleLambda)
+				return ImmutableArray.Create(simpleLambda.Parameter);
+
+			if (lambda is ParenthesizedLambdaExpressionSyntax parenthesizedLambda)
+				return parenthesizedLambda.ParameterList.Parameters.ToImmutableArray();
+
+			return ImmutableArray<ParameterSyntax>.Empty;
+		}
+
+		private static ExpressionSyntax GetLeftmostDescendant(ExpressionSyntax expression)
+		{
+			ExpressionSyntax GetLeftmostChild(ExpressionSyntax x)
+			{
+				switch (x)
+				{
+					case InvocationExpressionSyntax invocation:
+						return invocation.Expression;
+
+					case MemberAccessExpressionSyntax memberAccess:
+						return memberAccess.Expression;
+
+					case ConditionalAccessExpressionSyntax conditionalAccess:
+						return conditionalAccess.Expression;
+
+					case ElementAccessExpressionSyntax elementAccess:
+						return elementAccess.Expression;
+
+					default:
+						return null;
+				}
+			}
+
+			var currentExpression = expression;
+			while (true)
+			{
+				var nextChild = GetLeftmostChild(currentExpression);
+				if (nextChild is null)
+					break;
+				currentExpression = nextChild;
+			}
+
+			return currentExpression;
+		}
+
+		private static async Task<Document> ReplaceValueAsync(Document document, ExpressionSyntax replacementTarget, ExpressionSyntax replacementExpression, CancellationToken cancellationToken)
+		{
+			var root = (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false))
+				.ReplaceNode(
+					replacementTarget,
+					replacementExpression);
+
+			var ifNotNullUsingDirective = root.DescendantNodes()
+				.OfType<UsingDirectiveSyntax>()
+				.FirstOrDefault(x => AreEquivalent(x.Name, s_ifNotNullNamespace));
+
+			if (ifNotNullUsingDirective != null)
+				root = root.ReplaceNode(ifNotNullUsingDirective, ifNotNullUsingDirective.WithAdditionalAnnotations(Simplifier.Annotation));
+
+			return await Simplifier.ReduceAsync(
+				await Simplifier.ReduceAsync(document.WithSyntaxRoot(root), cancellationToken: cancellationToken).ConfigureAwait(false),
+				cancellationToken: cancellationToken).ConfigureAwait(false);
+		}
+
+		private static ExpressionSyntax ReplaceIdentifiers(string expression, params (string OriginalIdentifierName, ExpressionSyntax Replacement)[] identifiers) =>
+			SimplifiableParentheses(ReplaceIdentifiers(ParseExpression(expression), identifiers));
+
+		private static ExpressionSyntax ReplaceIdentifiers(ExpressionSyntax expression, params (string OriginalIdentifierName, ExpressionSyntax Replacement)[] identifiers) =>
+			identifiers.Aggregate(
+				expression,
+				(currentExpression, identifier) => ReplaceIdentifier(currentExpression, identifier.OriginalIdentifierName, identifier.Replacement));
+
+		private static ExpressionSyntax ReplaceIdentifier(ExpressionSyntax expression, string originalIdentifierName, ExpressionSyntax replacement)
+		{
+			var targetNodes = expression.DescendantNodes()
+				.OfType<IdentifierNameSyntax>()
+				.Where(x => x.Identifier.Text == originalIdentifierName)
+				.ToList();
+
+			if (targetNodes.Count == 0)
+				throw new InvalidOperationException($"The identifier {originalIdentifierName} was not found in the expression.");
+
+			return expression.ReplaceNodes(targetNodes, (original, updated) => replacement.WithTriviaFrom(original));
+		}
+
+		private static ParenthesizedExpressionSyntax SimplifiableParentheses(ExpressionSyntax expression) =>
+			ParenthesizedExpression(expression).WithAdditionalAnnotations(Simplifier.Annotation);
+
+		private static TypeSyntax GetTypeSyntax(ITypeSymbol typeName) =>
+			ParseSimplifiableTypeName(typeName.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+
+		private static TypeSyntax ParseSimplifiableTypeName(string name) =>
+			ParseTypeName(name).WithAdditionalAnnotations(Simplifier.Annotation);
+
+		private static readonly NameSyntax s_ifNotNullNamespace = ParseName("Libronix.Utility.IfNotNull");
+
+		private const string c_fixName = "use-modern-language-features";
+	}
+}

--- a/src/Faithlife.Analyzers/IfNotNullFixAllProvider.cs
+++ b/src/Faithlife.Analyzers/IfNotNullFixAllProvider.cs
@@ -1,0 +1,135 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Faithlife.Analyzers
+{
+	internal sealed class IfNotNullFixAllProvider : FixAllProvider
+	{
+		private IfNotNullFixAllProvider()
+		{
+		}
+
+		public static IfNotNullFixAllProvider Instance { get; } = new IfNotNullFixAllProvider();
+
+		public override async Task<CodeAction> GetFixAsync(FixAllContext fixAllContext)
+		{
+			IEnumerable<Diagnostic> allDiagnostics;
+			IEnumerable<(Document Document, SyntaxTree SyntaxTree)> allSyntaxTrees;
+
+			switch (fixAllContext.Scope)
+			{
+			case FixAllScope.Document:
+				{
+					allDiagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(fixAllContext.Document).ConfigureAwait(false);
+					allSyntaxTrees = new[] { (fixAllContext.Document, await fixAllContext.Document.GetSyntaxTreeAsync(fixAllContext.CancellationToken).ConfigureAwait(false)) };
+					break;
+				}
+
+			case FixAllScope.Project:
+				{
+					allDiagnostics = await fixAllContext.GetAllDiagnosticsAsync(fixAllContext.Project).ConfigureAwait(false);
+					allSyntaxTrees = await Task.WhenAll(
+						fixAllContext.Project.Documents
+							.Select(async document => (document, await document.GetSyntaxTreeAsync(fixAllContext.CancellationToken).ConfigureAwait(false))))
+						.ConfigureAwait(false);
+
+					break;
+				}
+
+			case FixAllScope.Solution:
+				{
+					var solutionDiagnostics = await Task.WhenAll(fixAllContext.Solution.Projects.Select(async project => await fixAllContext.GetAllDiagnosticsAsync(project).ConfigureAwait(false))).ConfigureAwait(false);
+					allDiagnostics = solutionDiagnostics.SelectMany(x => x);
+					allSyntaxTrees = await Task.WhenAll(fixAllContext.Solution.Projects
+						.SelectMany(x => x.Documents)
+						.Select(async document => (document, await document.GetSyntaxTreeAsync(fixAllContext.CancellationToken).ConfigureAwait(false))))
+						.ConfigureAwait(false);
+
+					break;
+				}
+
+			default:
+				return null;
+			}
+
+			var documentsWithDiagnostics = allSyntaxTrees
+				.GroupJoin(allDiagnostics, x => x.SyntaxTree, x => x.Location.SourceTree, (tuple, diagnostics) => (tuple.Document, Diagnostics: diagnostics.ToImmutableArray()))
+				.Where(x => x.Diagnostics.Length != 0)
+				.ToImmutableArray();
+
+			// The fixes for individual documents can be calculated in parallel, but fixes within a document
+			// need to be calculated serially, so fixes that introduce new variable declares don't choose
+			// conflicting names.
+			var updatedDocuments = await Task.WhenAll(
+				documentsWithDiagnostics
+					.Select(async x =>
+						await Task.Run(
+							async () => await GetDocumentFixAsync(fixAllContext, x.Document, x.Diagnostics).ConfigureAwait(false),
+							fixAllContext.CancellationToken)
+							.ConfigureAwait(false)))
+				.ConfigureAwait(false);
+
+			var updatedSolution = await updatedDocuments
+				.Where(x => x is object)
+				.Aggregate(
+					Task.FromResult(fixAllContext.Solution),
+					async (solutionAsync, document) =>
+						(await solutionAsync.ConfigureAwait(false))
+							.WithDocumentText(
+								document.Id,
+								await document.GetTextAsync(fixAllContext.CancellationToken).ConfigureAwait(false)))
+				.ConfigureAwait(false);
+
+			return CodeAction.Create("Update solution", token => Task.FromResult(updatedSolution));
+		}
+
+		private static async Task<Document> GetDocumentFixAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> initialDiagnostics)
+		{
+			var currentDocument = document;
+			var diagnostics = initialDiagnostics;
+			while (diagnostics.Length != 0)
+			{
+				CodeAction firstFix = null;
+
+				foreach (var diagnostic in diagnostics)
+				{
+					using (var innerCancellationTokenSource = new CancellationTokenSource())
+					using (var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(fixAllContext.CancellationToken, innerCancellationTokenSource.Token))
+					{
+						void HandleCodeFix(CodeAction codeAction, ImmutableArray<Diagnostic> fixedDiagnostics)
+						{
+							firstFix = codeAction;
+							innerCancellationTokenSource.Cancel();
+						}
+
+						await fixAllContext.CodeFixProvider.RegisterCodeFixesAsync(new CodeFixContext(currentDocument, diagnostic, HandleCodeFix, fixAllContext.CancellationToken)).ConfigureAwait(false);
+					}
+
+					if (firstFix is object)
+						break;
+				}
+
+				if (firstFix is null)
+					break;
+
+				var operations = await firstFix.GetOperationsAsync(fixAllContext.CancellationToken).ConfigureAwait(false);
+
+				var changedSolution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
+
+				currentDocument = changedSolution.GetDocument(document.Id);
+				diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(currentDocument).ConfigureAwait(false);
+			}
+
+			if (currentDocument == document)
+				return null;
+
+			return currentDocument;
+		}
+	}
+}

--- a/src/Faithlife.Analyzers/SyntaxUtility.cs
+++ b/src/Faithlife.Analyzers/SyntaxUtility.cs
@@ -94,7 +94,7 @@ namespace Faithlife.Analyzers
 				.ToList();
 
 			if (targetNodes.Count == 0)
-				throw new InvalidOperationException($"The identifier {originalIdentifierName} was not found in the expression.");
+				return expression;
 
 			return expression.ReplaceNodes(targetNodes, (original, updated) => replacement.WithTriviaFrom(original));
 		}

--- a/src/Faithlife.Analyzers/SyntaxUtility.cs
+++ b/src/Faithlife.Analyzers/SyntaxUtility.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Faithlife.Analyzers
+{
+	internal static class SyntaxUtility
+	{
+		/// <summary>
+		/// Generates an identifier name that has a high likelihood of not causing any naming conflicts.
+		/// </summary>
+		/// <param name="desiredName">The default name for the identifier.</param>
+		/// <param name="declarationLocation">A syntax location within the member in which the identifier will be declared.</param>
+		/// <param name="originalDeclaration">
+		/// An optional syntax node designating an existing variable declaration.
+		/// If specified, this node will be ignored when checking for uniqueness.
+		/// </param>
+		/// <returns>A <see cref="Microsoft.CodeAnalysis.SyntaxToken">SyntaxToken</see> for the new identifier.</returns>
+		/// <remarks>
+		/// Currently, this method takes a conservative approach to declarations within the member and pays no attention at all
+		/// to identifiers declared outside the scope of the member.
+		/// </remarks>
+		public static SyntaxToken GetHoistableIdentifier(string desiredName, SyntaxNode declarationLocation, SyntaxNode originalDeclaration = null)
+		{
+			if (desiredName is null)
+				throw new ArgumentNullException(nameof(desiredName));
+			if (declarationLocation is null)
+				throw new ArgumentNullException(nameof(declarationLocation));
+
+			var containingMember = declarationLocation.FirstAncestorOrSelf<MemberDeclarationSyntax>();
+			if (containingMember is null)
+				throw new InvalidOperationException("Cannot declare a variable at this scope.");
+
+			// Currently, this makes no attempt to be clever about scoping rules.
+			var unavailableNames = new HashSet<string>(
+				containingMember
+					.DescendantNodes()
+					.Select(node =>
+					{
+						if (node == originalDeclaration)
+							return default;
+						if (node is ParameterSyntax parameter)
+							return parameter.Identifier;
+						if (node is TypeParameterSyntax typeParameter)
+							return typeParameter.Identifier;
+						if (node is VariableDeclaratorSyntax variableDeclarator)
+							return variableDeclarator.Identifier;
+						if (node is SingleVariableDesignationSyntax singleVariableDesignation)
+							return singleVariableDesignation.Identifier;
+						if (node is FromClauseSyntax fromClause)
+							return fromClause.Identifier;
+						if (node is LetClauseSyntax letClause)
+							return letClause.Identifier;
+						if (node is QueryContinuationSyntax queryContinuation)
+							return queryContinuation.Identifier;
+
+						return default;
+					})
+					.Select(x => x.Text)
+					.Where(x => x?.StartsWith(desiredName, StringComparison.Ordinal) ?? false),
+				StringComparer.Ordinal);
+
+			// This will also make "value" unavailable within the get accessor.
+			if (containingMember is BasePropertyDeclarationSyntax)
+				unavailableNames.Add("value");
+
+			var suffix = 0;
+			var candidateName = desiredName;
+			while (unavailableNames.Contains(candidateName))
+				candidateName = desiredName + (++suffix).ToString(CultureInfo.InvariantCulture);
+
+			return Identifier(candidateName);
+		}
+	}
+}

--- a/src/Faithlife.Analyzers/UntilCanceledCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/UntilCanceledCodeFixProvider.cs
@@ -113,18 +113,11 @@ namespace Faithlife.Analyzers
 				.ReplaceNode(containingMethod, containingMethod
 					.ReplaceNode(argumentList, replacement.WithAdditionalAnnotations(Formatter.Annotation))
 					.AddParameterListParameters(SyntaxFactory.Parameter(SyntaxFactory.Identifier(candidateName))
-						.WithType(s_iworkStateTypeName)
-						.WithAdditionalAnnotations(Simplifier.Annotation)));
+						.WithType(s_iworkStateTypeName)));
 
 			return await Simplifier.ReduceAsync(document.WithSyntaxRoot(root), cancellationToken: cancellationToken).ConfigureAwait(false);
 		}
 
-		static readonly QualifiedNameSyntax s_iworkStateTypeName = SyntaxFactory.QualifiedName(
-			SyntaxFactory.QualifiedName(
-				SyntaxFactory.QualifiedName(
-					SyntaxFactory.IdentifierName("Libronix"),
-					SyntaxFactory.IdentifierName("Utility")),
-				SyntaxFactory.IdentifierName("Threading")),
-			SyntaxFactory.IdentifierName("IWorkState"));
+		private static readonly TypeSyntax s_iworkStateTypeName = SyntaxUtility.ParseSimplifiableTypeName("Libronix.Utility.Threading.IWorkState");
 	}
 }

--- a/tests/Faithlife.Analyzers.Tests/IfNotNullTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/IfNotNullTests.cs
@@ -46,29 +46,41 @@ namespace Faithlife.Analyzers.Tests
 		[TestCase(
 			"new ReferenceThing()",
 			"var result = possiblyNull.IfNotNull(x => (x.CalculateValue()));",
-			"var result = possiblyNull is ReferenceThing x ? (x.CalculateValue()) : default(ReferenceThing);")]
+			"var result = possiblyNull is ReferenceThing ? (possiblyNull.CalculateValue()) : default(ReferenceThing);")]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.RecursiveProperty.IfNotNull(x => (x.CalculateValue()));",
+			"var result = possiblyNull.RecursiveProperty is ReferenceThing x ? (x.CalculateValue()) : default(ReferenceThing);")]
 		[TestCase(
 			"new ReferenceThing()",
 			"var result = possiblyNull.IfNotNull(x => (x).CalculateValue());",
-			"var result = possiblyNull is ReferenceThing x ? (x).CalculateValue() : default(ReferenceThing);")]
+			"var result = possiblyNull is ReferenceThing ? (possiblyNull).CalculateValue() : default(ReferenceThing);")]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.RecursiveProperty.IfNotNull(x => (x).CalculateValue());",
+			"var result = possiblyNull.RecursiveProperty is ReferenceThing x ? (x).CalculateValue() : default(ReferenceThing);")]
 		[TestCase(
 			"new ReferenceThing()",
 			"var result = possiblyNull.IfNotNull(x => (x.RecursiveProperty).CalculateValue());",
-			"var result = possiblyNull is ReferenceThing x ? (x.RecursiveProperty).CalculateValue() : default(ReferenceThing);")]
+			"var result = possiblyNull is ReferenceThing ? (possiblyNull.RecursiveProperty).CalculateValue() : default(ReferenceThing);")]
 		[TestCase(
 			"new ReferenceThing()",
 			"var result = possiblyNull.IfNotNull(x => ((x.RecursiveProperty).RecursiveProperty).CalculateValue());",
-			"var result = possiblyNull is ReferenceThing x ? ((x.RecursiveProperty).RecursiveProperty).CalculateValue() : default(ReferenceThing);")]
+			"var result = possiblyNull is ReferenceThing ? ((possiblyNull.RecursiveProperty).RecursiveProperty).CalculateValue() : default(ReferenceThing);")]
 		[TestCase(
 			"new ReferenceThing()",
 			"var result = possiblyNull.IfNotNull(x => (x.RecursiveProperty?.RecursiveProperty).CalculateValue());",
-			"var result = possiblyNull is ReferenceThing x ? (x.RecursiveProperty?.RecursiveProperty).CalculateValue() : default(ReferenceThing);")]
+			"var result = possiblyNull is ReferenceThing ? (possiblyNull.RecursiveProperty?.RecursiveProperty).CalculateValue() : default(ReferenceThing);")]
 		// When using pattern matching, the input type must be used for the declaration type.
 		// (in most of these tests, the input type and output type are the same)
 		[TestCase(
 			"new ReferenceThing()",
 			"var result = possiblyNull.IfNotNull(x => (x.ValueTypeProperty));",
-			"var result = possiblyNull is ReferenceThing x ? (x.ValueTypeProperty) : default(int);")]
+			"var result = possiblyNull is ReferenceThing ? (possiblyNull.ValueTypeProperty) : default(int);")]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.RecursiveProperty.IfNotNull(x => (x.ValueTypeProperty));",
+			"var result = possiblyNull.RecursiveProperty is ReferenceThing x ? (x.ValueTypeProperty) : default(int);")]
 		// Conditional operators should also work with indexed access.
 		[TestCase(
 			"new ReferenceThing()",
@@ -88,11 +100,15 @@ namespace Faithlife.Analyzers.Tests
 		[TestCase(
 			"new ReferenceThing()",
 			"var result = possiblyNull.IfNotNull(ReferenceThing.CalculateStatic);",
-			"var result = possiblyNull is ReferenceThing value ? ReferenceThing.CalculateStatic(value) : default(ReferenceThing);")]
+			"var result = possiblyNull is ReferenceThing ? ReferenceThing.CalculateStatic(possiblyNull) : default(ReferenceThing);")]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.RecursiveProperty.IfNotNull(ReferenceThing.CalculateStatic);",
+			"var result = possiblyNull.RecursiveProperty is ReferenceThing value ? ReferenceThing.CalculateStatic(value) : default(ReferenceThing);")]
 		[TestCase(
 			"new ReferenceThing()",
 			"var result = possiblyNull.IfNotNull(ReferenceThing.CalculateStatic, ReferenceThing.Factory);",
-			"var result = possiblyNull is ReferenceThing value ? ReferenceThing.CalculateStatic(value) : ReferenceThing.Factory();")]
+			"var result = possiblyNull is ReferenceThing ? ReferenceThing.CalculateStatic(possiblyNull) : ReferenceThing.Factory();")]
 		// The results using Nullable<T> generally look the same, but they require special handling.
 		[TestCase(
 			"new ReferenceThing()",
@@ -130,11 +146,19 @@ namespace Faithlife.Analyzers.Tests
 		[TestCase(
 			"new ReferenceThing()",
 			"var result = possiblyNull.IfNotNull(x => x.CalculateValue(), () => new ReferenceThing());",
-			"var result = possiblyNull is ReferenceThing x ? x.CalculateValue() : new ReferenceThing();")]
+			"var result = possiblyNull is ReferenceThing ? possiblyNull.CalculateValue() : new ReferenceThing();")]
 		[TestCase(
 			"new ReferenceThing()",
 			"var result = possiblyNull.IfNotNull(x => x.CalculateValue(), new ReferenceThing());",
-			"var result = possiblyNull is ReferenceThing x ? x.CalculateValue() : new ReferenceThing();")]
+			"var result = possiblyNull is ReferenceThing ? possiblyNull.CalculateValue() : new ReferenceThing();")]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.RecursiveProperty.IfNotNull(x => x.CalculateValue(), () => new ReferenceThing());",
+			"var result = possiblyNull.RecursiveProperty is ReferenceThing x ? x.CalculateValue() : new ReferenceThing();")]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.RecursiveProperty.IfNotNull(x => x.CalculateValue(), new ReferenceThing());",
+			"var result = possiblyNull.RecursiveProperty is ReferenceThing x ? x.CalculateValue() : new ReferenceThing();")]
 		// Calling IfNotNull on a delegate that is immediately invoked results in some special cases.
 		[TestCase(
 			"(Func<ReferenceThing>) new ReferenceThing().CalculateValue",
@@ -156,7 +180,11 @@ namespace Faithlife.Analyzers.Tests
 		[TestCase(
 			"new ReferenceThing()",
 			"var result = possiblyNull.IfNotNull(x => x.CalculateValue(x));",
-			"var result = possiblyNull is ReferenceThing x ? x.CalculateValue(x) : default(ReferenceThing);")]
+			"var result = possiblyNull is ReferenceThing ? possiblyNull.CalculateValue(possiblyNull) : default(ReferenceThing);")]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.RecursiveProperty.IfNotNull(x => x.CalculateValue(x));",
+			"var result = possiblyNull.RecursiveProperty is ReferenceThing x ? x.CalculateValue(x) : default(ReferenceThing);")]
 		// This cast makes the call equivalent to the null-conditional operator, which means that
 		// pattern matching is unnecessary and the cast can be discarded.
 		[TestCase(
@@ -174,12 +202,12 @@ namespace Faithlife.Analyzers.Tests
 		[TestCase(
 			"new ReferenceThing()",
 			"var result = possiblyNull.IfNotNull(x => new { Property = \"value\" }, () => new { Property = \"other value\" });",
-			"var result = possiblyNull is ReferenceThing x ? (new { Property = \"value\" }) : new { Property = \"other value\" };")]
+			"var result = possiblyNull is ReferenceThing ? (new { Property = \"value\" }) : new { Property = \"other value\" };")]
 		// A new expression with no default value can still be transformed if it is the left hand side of a null-coalescing operator.
 		[TestCase(
 			"new ReferenceThing()",
 			"var result = possiblyNull.IfNotNull(x => new { Property = \"value\" }) ?? new { Property = \"other value\" };",
-			"var result = possiblyNull is ReferenceThing x ? new { Property = \"value\" } : new { Property = \"other value\" };")]
+			"var result = possiblyNull is ReferenceThing ? new { Property = \"value\" } : new { Property = \"other value\" };")]
 		public void SimpleMethodCall(string possiblyNull, string call, string fixedCall)
 		{
 			string createProgram(string actualCall) =>
@@ -226,12 +254,12 @@ namespace TestProgram
 		[TestCase(
 			"new ReferenceThing()",
 			"var result = possiblyNull.IfNotNull(x => ReferenceThing.CalculateStatic(x)).IfNotNull(x => ReferenceThing.CalculateStatic(x));",
-			"var result = (possiblyNull is ReferenceThing x ? ReferenceThing.CalculateStatic(x) : default(ReferenceThing)) is ReferenceThing x1 ? ReferenceThing.CalculateStatic(x1) : default(ReferenceThing);",
+			"var result = (possiblyNull is ReferenceThing ? ReferenceThing.CalculateStatic(possiblyNull) : default(ReferenceThing)) is ReferenceThing x1 ? ReferenceThing.CalculateStatic(x1) : default(ReferenceThing);",
 			17, 17)]
 		[TestCase(
 			"new ReferenceThing()",
 			"var result = possiblyNull.IfNotNull(ReferenceThing.CalculateStatic).IfNotNull(ReferenceThing.CalculateStatic);",
-			"var result = (possiblyNull is ReferenceThing value1 ? ReferenceThing.CalculateStatic(value1) : default(ReferenceThing)) is ReferenceThing value ? ReferenceThing.CalculateStatic(value) : default(ReferenceThing);",
+			"var result = (possiblyNull is ReferenceThing ? ReferenceThing.CalculateStatic(possiblyNull) : default(ReferenceThing)) is ReferenceThing value ? ReferenceThing.CalculateStatic(value) : default(ReferenceThing);",
 			17, 17)]
 		public void MultipleMethodCalls(string possiblyNull, string call, string fixedCall, int firstColumn, int secondColumn)
 		{
@@ -278,7 +306,7 @@ namespace TestProgram
 		[TestCase(
 			"new ReferenceThing()",
 			"possiblyNull.IfNotNull(x => x.Method(), () => throw new InvalidOperationException());",
-			"if (possiblyNull is ReferenceThing x)\n\t\t\t\tx.Method();\n\t\t\telse\n\t\t\t\tthrow new InvalidOperationException();")]
+			"if (possiblyNull is ReferenceThing)\n\t\t\t\tpossiblyNull.Method();\n\t\t\telse\n\t\t\t\tthrow new InvalidOperationException();")]
 		[TestCase(
 			"(ValueThing?) new ValueThing()",
 			"possiblyNull.IfNotNull((ValueThing x) => x.Method(), () => throw new InvalidOperationException());",
@@ -313,6 +341,42 @@ namespace TestProgram
 
 			// The fixer should decline to make any modifications to unsupported calls.
 			VerifyCSharpFix(invalidProgram, fixedCall is null ? invalidProgram : createProgram(fixedCall).Replace("using Libronix.Utility.IfNotNull;\n", ""));
+		}
+
+		public void NonLocalInvocation()
+		{
+			string createProgram(string actualCall) =>
+				c_preamble + @"
+namespace TestProgram
+{
+	internal class TestClass
+	{
+		public event Action OnAction;
+
+		public void CallIfNotNull()
+		{
+			" + actualCall + @"
+		}
+	}
+}";
+
+			var expected = new DiagnosticResult
+			{
+				Id = IfNotNullAnalyzer.DiagnosticId,
+				Message = "Prefer modern language features over IfNotNull usage.",
+				Severity = DiagnosticSeverity.Info,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 8, 4) },
+			};
+
+			string invalidProgram = createProgram("OnAction.IfNotNull(x => x(), () => throw new InvalidOperationException());");
+
+			VerifyCSharpDiagnostic(invalidProgram, expected);
+
+			// Ensure that invocations on identifiers that are *not* local variables receive a local variable definition.
+			VerifyCSharpFix(invalidProgram, createProgram(@"if (OnAction is Action x)
+				x();
+			else
+				throw new InvalidOperationException();").Replace("using Libronix.Utility.IfNotNull;\n", ""));
 		}
 
 		[TestCase(

--- a/tests/Faithlife.Analyzers.Tests/IfNotNullTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/IfNotNullTests.cs
@@ -269,29 +269,21 @@ namespace TestProgram
 
 		[TestCase(
 			"new ReferenceThing()",
-			"possiblyNull.IfNotNull(x => x.Method());")]
+			"possiblyNull.IfNotNull(x => x.Method());",
+			"possiblyNull?.Method();")]
+		[TestCase(
+			"(ValueThing?) new ValueThing()",
+			"possiblyNull.IfNotNull((ValueThing x) => x.Method());",
+			"possiblyNull?.Method();")]
 		[TestCase(
 			"new ReferenceThing()",
-			"IfNotNullExtensionMethod.IfNotNull(possiblyNull, x => x.Method());")]
+			"possiblyNull.IfNotNull(x => x.Method(), () => throw new InvalidOperationException());",
+			"if (possiblyNull is ReferenceThing x)\n\t\t\t\tx.Method();\n\t\t\telse\n\t\t\t\tthrow new InvalidOperationException();")]
 		[TestCase(
 			"(ValueThing?) new ValueThing()",
-			"possiblyNull.IfNotNull((ValueThing x) => x.Method());")]
-		[TestCase(
-			"(ValueThing?) new ValueThing()",
-			"IfNotNullExtensionMethod.IfNotNull(possiblyNull, (ValueThing x) => x.Method());")]
-		[TestCase(
-			"new ReferenceThing()",
-			"possiblyNull.IfNotNull(x => x.Method(), () => throw new InvalidOperationException());")]
-		[TestCase(
-			"new ReferenceThing()",
-			"IfNotNullExtensionMethod.IfNotNull(possiblyNull, x => x.Method(), () => throw new InvalidOperationException());")]
-		[TestCase(
-			"(ValueThing?) new ValueThing()",
-			"possiblyNull.IfNotNull((ValueThing x) => x.Method(), () => throw new InvalidOperationException());")]
-		[TestCase(
-			"(ValueThing?) new ValueThing()",
-			"IfNotNullExtensionMethod.IfNotNull(possiblyNull, (ValueThing x) => x.Method(), () => throw new InvalidOperationException());")]
-		public void VoidInvocation(string possiblyNull, string call)
+			"possiblyNull.IfNotNull((ValueThing x) => x.Method(), () => throw new InvalidOperationException());",
+			"if (possiblyNull is ValueThing x)\n\t\t\t\tx.Method();\n\t\t\telse\n\t\t\t\tthrow new InvalidOperationException();")]
+		public void VoidInvocation(string possiblyNull, string call, string fixedCall)
 		{
 			string createProgram(string actualCall) =>
 				c_preamble + @"
@@ -319,8 +311,8 @@ namespace TestProgram
 
 			VerifyCSharpDiagnostic(invalidProgram, expected);
 
-			// The fixer should decline to make any modifications to these calls.
-			VerifyCSharpFix(invalidProgram, invalidProgram);
+			// The fixer should decline to make any modifications to unsupported calls.
+			VerifyCSharpFix(invalidProgram, fixedCall is null ? invalidProgram : createProgram(fixedCall).Replace("using Libronix.Utility.IfNotNull;\n", ""));
 		}
 
 		[TestCase(

--- a/tests/Faithlife.Analyzers.Tests/IfNotNullTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/IfNotNullTests.cs
@@ -1,0 +1,423 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Framework;
+
+namespace Faithlife.Analyzers.Tests
+{
+	[TestFixture]
+	public sealed class IfNotNullTests : CodeFixVerifier
+	{
+		// An expression evaluating to a value type without a supplied default
+		// needs to use the null coalescing to maintain the correct type.
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => x.ValueTypeProperty);",
+			"var result = possiblyNull?.ValueTypeProperty ?? default(int);")]
+		// Complex expressions of a value type still need the null coalescing operator
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => x.CalculateValue().ValueTypeProperty);",
+			"var result = possiblyNull?.CalculateValue().ValueTypeProperty ?? default(int);")]
+		// Most usages of the default parameter cannot be combined with the conditional operator,
+		// but value types are fine.
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => x.ValueTypeProperty, () => 0);",
+			"var result = possiblyNull?.ValueTypeProperty ?? 0;")]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = IfNotNullExtensionMethod.IfNotNull(possiblyNull, x => x.ValueTypeProperty, () => 0);",
+			"var result = possiblyNull?.ValueTypeProperty ?? 0;")]
+		// A method invocation can be performed using the conditional operator.
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => x.CalculateValue());",
+			"var result = possiblyNull?.CalculateValue();")]
+		// The presences of conditional operators within the expression shouldn't prevent
+		// the use of a new conditional operator.
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => x.RecursiveProperty?.CalculateValue());",
+			"var result = possiblyNull?.RecursiveProperty?.CalculateValue();")]
+		// Parentheses at the root will prevent the use of the conditional operator because
+		// there are some weird edge cases, but it should still fall back to pattern matching
+		// just fine.
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => (x.CalculateValue()));",
+			"var result = possiblyNull is ReferenceThing x ? (x.CalculateValue()) : default(ReferenceThing);")]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => (x).CalculateValue());",
+			"var result = possiblyNull is ReferenceThing x ? (x).CalculateValue() : default(ReferenceThing);")]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => (x.RecursiveProperty).CalculateValue());",
+			"var result = possiblyNull is ReferenceThing x ? (x.RecursiveProperty).CalculateValue() : default(ReferenceThing);")]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => ((x.RecursiveProperty).RecursiveProperty).CalculateValue());",
+			"var result = possiblyNull is ReferenceThing x ? ((x.RecursiveProperty).RecursiveProperty).CalculateValue() : default(ReferenceThing);")]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => (x.RecursiveProperty?.RecursiveProperty).CalculateValue());",
+			"var result = possiblyNull is ReferenceThing x ? (x.RecursiveProperty?.RecursiveProperty).CalculateValue() : default(ReferenceThing);")]
+		// When using pattern matching, the input type must be used for the declaration type.
+		// (in most of these tests, the input type and output type are the same)
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => (x.ValueTypeProperty));",
+			"var result = possiblyNull is ReferenceThing x ? (x.ValueTypeProperty) : default(int);")]
+		// Conditional operators should also work with indexed access.
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => x[0]);",
+			"var result = possiblyNull?[0];")]
+		// Nothing fancy should happen if indexed access is later in the expression.
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => x.RecursiveProperty[0]);",
+			"var result = possiblyNull?.RecursiveProperty[0];")]
+		// A conditional operator for indexed access later in the expression shouldn't break anything.
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => x.RecursiveProperty?[0]);",
+			"var result = possiblyNull?.RecursiveProperty?[0];")]
+		// Passing delegate references should be transformed into appropriate invocations.
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(ReferenceThing.CalculateStatic);",
+			"var result = possiblyNull is ReferenceThing value ? ReferenceThing.CalculateStatic(value) : default(ReferenceThing);")]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(ReferenceThing.CalculateStatic, ReferenceThing.Factory);",
+			"var result = possiblyNull is ReferenceThing value ? ReferenceThing.CalculateStatic(value) : ReferenceThing.Factory();")]
+		// The results using Nullable<T> generally look the same, but they require special handling.
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => x.NullableProperty);",
+			"var result = possiblyNull?.NullableProperty;")]
+		[TestCase(
+			"(ValueThing?) new ValueThing()",
+			"var result = possiblyNull.IfNotNull((ValueThing x) => x.ValueTypeProperty);",
+			"var result = possiblyNull?.ValueTypeProperty ?? default(int);")]
+		[TestCase(
+			"(ValueThing?) new ValueThing()",
+			"var result = possiblyNull.IfNotNull((ValueThing x) => x.RecursiveProperty);",
+			"var result = possiblyNull?.RecursiveProperty ?? default(ValueThing);")]
+		[TestCase(
+			"(ValueThing?) new ValueThing()",
+			"var result = IfNotNullExtensionMethod.IfNotNull(possiblyNull, (ValueThing x) => x.ValueTypeProperty);",
+			"var result = possiblyNull?.ValueTypeProperty ?? default(int);")]
+		[TestCase(
+			"(ValueThing?) new ValueThing()",
+			"var result = possiblyNull.IfNotNull((ValueThing x) => x.ValueTypeProperty, 0);",
+			"var result = possiblyNull?.ValueTypeProperty ?? 0;")]
+		[TestCase(
+			"(ValueThing?) new ValueThing()",
+			"var result = IfNotNullExtensionMethod.IfNotNull(possiblyNull, (ValueThing x) => x.ValueTypeProperty, 0);",
+			"var result = possiblyNull?.ValueTypeProperty ?? 0;")]
+		[TestCase(
+			"(ValueThing?) new ValueThing()",
+			"var result = possiblyNull.IfNotNull((ValueThing x) => x.ValueTypeProperty, () => 0);",
+			"var result = possiblyNull?.ValueTypeProperty ?? 0;")]
+		[TestCase(
+			"(ValueThing?) new ValueThing()",
+			"var result = IfNotNullExtensionMethod.IfNotNull(possiblyNull, (ValueThing x) => x.ValueTypeProperty, () => 0);",
+			"var result = possiblyNull?.ValueTypeProperty ?? 0;")]
+		// Supplying a reference type default value requires falling back to pattern matching.
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => x.CalculateValue(), () => new ReferenceThing());",
+			"var result = possiblyNull is ReferenceThing x ? x.CalculateValue() : new ReferenceThing();")]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => x.CalculateValue(), new ReferenceThing());",
+			"var result = possiblyNull is ReferenceThing x ? x.CalculateValue() : new ReferenceThing();")]
+		// Calling IfNotNull on a delegate that is immediately invoked results in some special cases.
+		[TestCase(
+			"(Func<ReferenceThing>) new ReferenceThing().CalculateValue",
+			"var result = possiblyNull.IfNotNull(x => x());",
+			"var result = possiblyNull?.Invoke();")]
+		[TestCase(
+			"(Func<int>) new ReferenceThing().CalculateValueTypeValue",
+			"var result = possiblyNull.IfNotNull(x => x(), 0);",
+			"var result = possiblyNull?.Invoke() ?? 0;")]
+		[TestCase(
+			"(Func<int>) new ReferenceThing().CalculateValueTypeValue",
+			"var result = possiblyNull.IfNotNull(x => x(), () => 1);",
+			"var result = possiblyNull?.Invoke() ?? 1;")]
+		[TestCase(
+			"(Func<int>) new ReferenceThing().CalculateValueTypeValue",
+			"var result = possiblyNull.IfNotNull(x => x(), possiblyNull);",
+			"var result = possiblyNull?.Invoke() ?? possiblyNull();")]
+		// Multiple usages of the parameter should force the usage of pattern matching.
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => x.CalculateValue(x));",
+			"var result = possiblyNull is ReferenceThing x ? x.CalculateValue(x) : default(ReferenceThing);")]
+		// This cast makes the call equivalent to the null-conditional operator, which means that
+		// pattern matching is unnecessary and the cast can be discarded.
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => (int?) x.ValueTypeProperty);",
+			"var result = possiblyNull?.ValueTypeProperty;")]
+		// Anonymous types can sometimes prevent the code fixer from supplying a transformation, but
+		// this pattern should work.
+		[TestCase(
+			"new { Property = \"value\" }",
+			"var result = possiblyNull.IfNotNull(x => x.Property);",
+			"var result = possiblyNull?.Property;")]
+		// Invocations that return anonymous types often cannot be converted, but they work when a default value is explicitly
+		// provided.
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => new { Property = \"value\" }, () => new { Property = \"other value\" });",
+			"var result = possiblyNull is ReferenceThing x ? (new { Property = \"value\" }) : new { Property = \"other value\" };")]
+		// A new expression with no default value can still be transformed if it is the left hand side of a null-coalescing operator.
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => new { Property = \"value\" }) ?? new { Property = \"other value\" };",
+			"var result = possiblyNull is ReferenceThing x ? new { Property = \"value\" } : new { Property = \"other value\" };")]
+		public void SimpleMethodCall(string possiblyNull, string call, string fixedCall)
+		{
+			string createProgram(string actualCall) =>
+				c_preamble + @"
+namespace TestProgram
+{
+	internal static class TestClass
+	{
+		public static void CallIfNotNull()
+		{
+			var possiblyNull = " + possiblyNull + @";
+			" + actualCall + @"
+		}
+	}
+}";
+
+			var expected = new DiagnosticResult
+			{
+				Id = IfNotNullAnalyzer.DiagnosticId,
+				Message = "Prefer modern language features over IfNotNull usage.",
+				Severity = DiagnosticSeverity.Info,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 8, 17) },
+			};
+
+			string invalidProgram = createProgram(call);
+
+			VerifyCSharpDiagnostic(invalidProgram, expected);
+
+			string validProgram = createProgram(fixedCall).Replace("using Libronix.Utility.IfNotNull;\n", "");
+
+			VerifyCSharpFix(invalidProgram, validProgram);
+		}
+
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => x.RecursiveProperty.IfNotNull(y => y.CalculateValue()));",
+			"var result = possiblyNull?.RecursiveProperty?.CalculateValue();",
+			17, 45)]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => x.RecursiveProperty).IfNotNull(x => x.CalculateValue());",
+			"var result = possiblyNull?.RecursiveProperty?.CalculateValue();",
+			17, 17)]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => ReferenceThing.CalculateStatic(x)).IfNotNull(x => ReferenceThing.CalculateStatic(x));",
+			"var result = (possiblyNull is ReferenceThing x ? ReferenceThing.CalculateStatic(x) : default(ReferenceThing)) is ReferenceThing x1 ? ReferenceThing.CalculateStatic(x1) : default(ReferenceThing);",
+			17, 17)]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(ReferenceThing.CalculateStatic).IfNotNull(ReferenceThing.CalculateStatic);",
+			"var result = (possiblyNull is ReferenceThing value1 ? ReferenceThing.CalculateStatic(value1) : default(ReferenceThing)) is ReferenceThing value ? ReferenceThing.CalculateStatic(value) : default(ReferenceThing);",
+			17, 17)]
+		public void MultipleMethodCalls(string possiblyNull, string call, string fixedCall, int firstColumn, int secondColumn)
+		{
+			string createProgram(string actualCall) =>
+				c_preamble + @"
+namespace TestProgram
+{
+	internal static class TestClass
+	{
+		public static void CallIfNotNull()
+		{
+			var possiblyNull = " + possiblyNull + @";
+			" + actualCall + @"
+		}
+	}
+}";
+
+			DiagnosticResult CreateDiagnosticAtColumn(int column) =>
+				new DiagnosticResult
+				{
+					Id = IfNotNullAnalyzer.DiagnosticId,
+					Message = "Prefer modern language features over IfNotNull usage.",
+					Severity = DiagnosticSeverity.Info,
+					Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 8, column) },
+				};
+
+			string invalidProgram = createProgram(call);
+
+			VerifyCSharpDiagnostic(invalidProgram, CreateDiagnosticAtColumn(firstColumn), CreateDiagnosticAtColumn(secondColumn));
+
+			string validProgram = createProgram(fixedCall).Replace("using Libronix.Utility.IfNotNull;\n", "");
+
+			VerifyCSharpFix(invalidProgram, validProgram);
+		}
+
+		[TestCase(
+			"new ReferenceThing()",
+			"possiblyNull.IfNotNull(x => x.Method());")]
+		[TestCase(
+			"new ReferenceThing()",
+			"IfNotNullExtensionMethod.IfNotNull(possiblyNull, x => x.Method());")]
+		[TestCase(
+			"(ValueThing?) new ValueThing()",
+			"possiblyNull.IfNotNull((ValueThing x) => x.Method());")]
+		[TestCase(
+			"(ValueThing?) new ValueThing()",
+			"IfNotNullExtensionMethod.IfNotNull(possiblyNull, (ValueThing x) => x.Method());")]
+		[TestCase(
+			"new ReferenceThing()",
+			"possiblyNull.IfNotNull(x => x.Method(), () => throw new InvalidOperationException());")]
+		[TestCase(
+			"new ReferenceThing()",
+			"IfNotNullExtensionMethod.IfNotNull(possiblyNull, x => x.Method(), () => throw new InvalidOperationException());")]
+		[TestCase(
+			"(ValueThing?) new ValueThing()",
+			"possiblyNull.IfNotNull((ValueThing x) => x.Method(), () => throw new InvalidOperationException());")]
+		[TestCase(
+			"(ValueThing?) new ValueThing()",
+			"IfNotNullExtensionMethod.IfNotNull(possiblyNull, (ValueThing x) => x.Method(), () => throw new InvalidOperationException());")]
+		public void VoidInvocation(string possiblyNull, string call)
+		{
+			string createProgram(string actualCall) =>
+				c_preamble + @"
+namespace TestProgram
+{
+	internal static class TestClass
+	{
+		public static void CallIfNotNull()
+		{
+			var possiblyNull = " + possiblyNull + @";
+			" + actualCall + @"
+		}
+	}
+}";
+
+			var expected = new DiagnosticResult
+			{
+				Id = IfNotNullAnalyzer.DiagnosticId,
+				Message = "Prefer modern language features over IfNotNull usage.",
+				Severity = DiagnosticSeverity.Info,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 8, 4) },
+			};
+
+			string invalidProgram = createProgram(call);
+
+			VerifyCSharpDiagnostic(invalidProgram, expected);
+
+			// The fixer should decline to make any modifications to these calls.
+			VerifyCSharpFix(invalidProgram, invalidProgram);
+		}
+
+		[TestCase(
+			"System.Threading.Tasks.Task.FromResult(default(ReferenceThing))",
+			"var result = possiblyNull.IfNotNull(async x => await x);")]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => { return x.CalculateValue(); });")]
+		[TestCase(
+			"new ReferenceThing()",
+			"var result = possiblyNull.IfNotNull(x => new { Property = 5 });")]
+		[TestCase(
+			"new { Property = 5 }",
+			"var result = possiblyNull.IfNotNull(x => new[] { x });")]
+		public void UnhandledInvocation(string possiblyNull, string call)
+		{
+			string createProgram(string actualCall) =>
+				c_preamble + @"
+namespace TestProgram
+{
+	internal static class TestClass
+	{
+		public static void CallIfNotNull()
+		{
+			var possiblyNull = " + possiblyNull + @";
+			" + actualCall + @"
+		}
+	}
+}";
+
+			var expected = new DiagnosticResult
+			{
+				Id = IfNotNullAnalyzer.DiagnosticId,
+				Message = "Prefer modern language features over IfNotNull usage.",
+				Severity = DiagnosticSeverity.Info,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 8, 17) },
+			};
+
+			string invalidProgram = createProgram(call);
+
+			VerifyCSharpDiagnostic(invalidProgram, expected);
+
+			VerifyCSharpFix(invalidProgram, invalidProgram);
+		}
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new IfNotNullAnalyzer();
+
+		protected override CodeFixProvider GetCSharpCodeFixProvider() => new IfNotNullCodeFixProvider();
+
+		private const string c_preamble = @"using System;
+using Libronix.Utility.IfNotNull;
+using TestProgram;
+
+namespace Libronix.Utility.IfNotNull
+{
+	public static class IfNotNullExtensionMethod
+	{
+		public static TOutput IfNotNull<TInput, TOutput>(this TInput t, Func<TInput, TOutput> fn) where TInput : class => throw new NotImplementedException();
+		public static TOutput IfNotNull<TInput, TOutput>(this TInput? t, Func<TInput, TOutput> fn) where TInput : struct => throw new NotImplementedException();
+		public static TOutput IfNotNull<TInput, TOutput>(this TInput t, Func<TInput, TOutput> fn, TOutput def) where TInput : class => throw new NotImplementedException();
+		public static TOutput IfNotNull<TInput, TOutput>(this TInput? t, Func<TInput, TOutput> fn, TOutput def) where TInput : struct => throw new NotImplementedException();
+		public static TOutput IfNotNull<TInput, TOutput>(this TInput t, Func<TInput, TOutput> fn, Func<TOutput> def) where TInput : class => throw new NotImplementedException();
+		public static TOutput IfNotNull<TInput, TOutput>(this TInput? t, Func<TInput, TOutput> fn, Func<TOutput> def) where TInput : struct => throw new NotImplementedException();
+		public static void IfNotNull<TInput>(this TInput t, Action<TInput> fn) where TInput : class => throw new NotImplementedException();
+		public static void IfNotNull<TInput>(this TInput? t, Action<TInput> fn) where TInput : struct => throw new NotImplementedException();
+		public static void IfNotNull<TInput>(this TInput t, Action<TInput> fn, Action def) where TInput : class => throw new NotImplementedException();
+		public static void IfNotNull<TInput>(this TInput? t, Action<TInput> fn, Action def) where TInput : struct => throw new NotImplementedException();
+	}
+}
+
+namespace TestProgram
+{
+	internal sealed class ReferenceThing
+	{
+		public int ValueTypeProperty => throw new NotImplementedException();
+		public int? NullableProperty => throw new NotImplementedException();
+		public ReferenceThing RecursiveProperty => throw new NotImplementedException();
+		public void Method() => throw new NotImplementedException();
+		public ReferenceThing CalculateValue() => throw new NotImplementedException();
+		public ReferenceThing CalculateValue(ReferenceThing input) => throw new NotImplementedException();
+		public int CalculateValueTypeValue() => throw new NotImplementedException();
+		public ReferenceThing this[int i] => throw new NotImplementedException();
+		public static ReferenceThing CalculateStatic(ReferenceThing x) => throw new NotImplementedException();
+		public static ReferenceThing Factory() => throw new NotImplementedException();
+	}
+
+	internal struct ValueThing
+	{
+		public int ValueTypeProperty => throw new NotImplementedException();
+		public ReferenceThing ReferenceTypeProperty => throw new NotImplementedException();
+		public ValueThing RecursiveProperty => throw new NotImplementedException();
+		public void Method() => throw new NotImplementedException();
+		public ValueThing CalculateValue() => throw new NotImplementedException();
+	}
+}
+";
+
+		private static readonly int c_preambleLength = c_preamble.Split('\n').Length;
+	}
+}

--- a/tests/Faithlife.Analyzers.Tests/InterpolatedStringTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/InterpolatedStringTests.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 namespace Faithlife.Analyzers.Tests
 {
 	[TestFixture]
-	public sealed class InterpolatedStringTests : CodeFixVerifier
+	public sealed class InterpolatedStringTests : DiagnosticVerifier
 	{
 		[Test]
 		public void ValidInterpolatedStrings()


### PR DESCRIPTION
Resolves part of #13.

# Cases that are handled

## The simple one

The easiest pattern is `foo.IfNotNull(x => foo.Bar)` *when `foo.Bar` is a reference type or `Nullable<T>`*. (more on this caveat later)

Invocations that match this pattern are transformed to `foo?.Bar`.

This pattern can be used as long as

* `x` is used only once, at the leftmost position.
* The expression consists of a single chain of member accesses, conditional accesses, element accesses, and method invocations.

## Value types

The behavior of `IfNotNull` differs from conditional access (`.?`) when the member (or element) accessed is of a value type.

Given a variable `foo` of the type

```csharp
class Foo
{
  public int Number { get; set; }
  public Foo Child { get; set; }
}
```

The expression `foo.IfNotNull(x => x.Number)` is an `int`, while `foo?.Number` is an `int?`. To accomodate this, value types (other than `Nullable<T>`) are transformed to the form `foo?.Number ?? default(int)`.

## Default values

The `IfNotNull` method provides two ways to specify a default value: either the value itself or a `Func<TOutput>` that lazily generates the value.

A naïve change would be to use the `null`-coalescing operator, as we did for value types. However, for nullable types (by which I mean both reference types and `Nullable<T>`), this is unsafe because the expression

```csharp
foo?.Child ?? customDefault
```

Will evaluate to `customDefault` when either `foo` is `null` *or* `foo.Child` is `null`, which is a change in behavior. On the other hand, it's perfectly fine to use `customDefault` and the `null`-coalescing operator when the output type is non-nullable.

One interesting caveat: since the `null`-coalescing operator short-circuits the right-hand side, any `Func<TOutput>` can simply be unwrapped and used as-is. *Technically*, this also means that a `TOutput` default value *cannot* simply be dropped in to the right hand side of the `null`-coalescing operator because any side effect might be lost. However, I've assumed that having an invocation of `IfNotNull` that depended on side effects caused by the evaluation of the default parameter would be *completely insane*, so I treat them all as if they were side-effect free. Hopefully, I will not regret this decision.

## Complicated expressions

While `IfNotNull` was originally meant as a replacement for the then-nonexistent `.?` operator, it has been used in a number of much more complex scenarios. So long as the argument to `IfNotNull` is an expression-bodied lambda, *all* of these can be converted to a use of pattern matching and the conditional access operator. For example, the invocation

```csharp
foo.IfNotNull(x => SomeMethod(x))
```

can be converted to

```csharp
foo is Foo x ? SomeMethod(x) : default(ReturnTypeOfSomeMethod)
```

This works because pattern matching against anything other than `null` will fail when the value is `null`. This pattern can also be used when a custom default value is supplied to an invocation of `IfNotNull` with a nullable output type.

The name of the lambda argument is preferred when hoisting it into this pattern, but sometimes, this will create conflicts with other named variables. To avoid this, a number is appended to non-unique variable names to make them unique.

## Delegate references

An invocation of the form `foo.IfNotNull(Converter)` is first transformed to `foo.IfNotNull(value => Converter(value))`, which allows for otherwise normal handling. This also works for delegate references specified as the default argument.

## Direct invocations

Given a variable `action` of type `Action<int>`, one could write `action.IfNotNull(x => x(5))`. While this *could* be handled with pattern matching, it is cleaner to first convert it to the form `action.IfNotNull(x => x.Invoke(5))`, which then allows it to be handled using the conditional access operator.

## Non-extension invocations

The code fixer will also (correctly!) modify direct invocations of `IfNotNull`.

## Casts to `Nullable<T>`

Some invocations are of the form `foo.IfNotNull(x => (ValueType?) x.ValueTypeProperty)`. The code fixer correctly figures out that this is compatible with the conditional access operator behavior and discards the cast.

## Simplification of `IfNotNull` and null-coalescing operator

Normally, an invocation of the form `foo.IfNotNull(x => new { x.Property })` cannot be converted to a pattern match because there's no type name that can be used for the `default` expression on the right-hand side of the ternary expression. (this *could* just use the plain `default` expression, but then I'd have to check whether the current project is at the correct minor version of C#…)

However, if the invocation is the left-hand expression to a null-coalescing operator, then we can turn the null-coalescing expression into a ternary.

For example,

```csharp
foo.IfNotNull(x => new { x.Property }) ?? new { Property = "value" }
```

can be converted to

```csharp
foo is InferredType x ? new { x.Property } : new { Property = "value" }
```

Note that this transformation is only safe to perform if the lambda expression is *known* to return a non-null value. Currently, object creation expressions are the only kind that get this treatment.

## Pattern matching on local variables

A call in the form

```csharp
foo.IfNotNull(x => Bar(x));
```

Can sometimes be converted with an `is` expression instead of a full pattern match, resulting in

```csharp
foo is InputType ? Bar(foo) : default(OutputType);
```

This will be done if all of the following hold:

* The invocation target is a single identifier. (that is `foo`, but not `foo.Bar` or `Method()`)
* The identifier is a local variable. (anything else might have side effects or race condtions. Even local variables might have race conditions if they're included in a closure, but I *hope* that's not going to be important)
* The type of the variable is not `Nullable<T>`

## `void` invocations

`IfNotNull` also has a few overloads that take `Action`s instead of `Func`s.

When possible, these will be converted to use conditional access.

When conditional access is not possible, the invocation will be converted to an `if` or `if`/`else` statement, but only if the invocation is its own statement.

# Cases that are not handled

By "not handled", I mean that the code fixer will not supply any suggestions.

## Block-bodied lambda expressions

There are a few of these lying around, and they *could* be handled by lifting the block into a local function. However, this would introduce a host of new edge cases. Take this one, for example:

```csharp
foo
  .Select(
    item => item.Bar.IfNotNull(bar =>
    {
      DoSomethingWithItem(item);
      return CalculateResult(bar);
    });
```

In this case, the lambda passed to `IfNotNull` forms a lexical closure over `item`, which is declared within an expression-bodied lambda. In order to correctly transform this into a local function, we would either need to detect the presence of the closure and add extra parameters to the local function or transform the lambda in the `Select` call to a block-bodied lambda so that it can host the local function.

And that's one of the easier transformations.

## `async` lambdas

It's possible to call `IfNotNull` with an `async` lambda in order to create a `Task`. I really hope that no one is doing this.

## C# 2.0-style anonymous delegates

Again, I hope that no one is doing this.

## Anonymous input or output types

Because the code fixer uses explicit type names in the output, these cannot be converted.

# Possibly controversial items

## The use of the word "hoistable"

I don't love this term, but I couldn't think of a better one.

## `ReplaceIdentifiers`

In a previous PR, I introduced `ReplaceIdentifier`, which allows for rewriting short code snippets. I had a few snippets with multiple replacements, and I didn't really like how multiple invocations of `ReplaceIdentifier` composed, so I introduced `ReplaceIdentifiers`, which takes a `params` array of replacements, which are expressed as tuples.

## Diagnostic level of `Info`

I think the most appropriate way to trigger warnings and errors is to use the `Obsolete` attribute on the `IfNotNull` methods themselves, so I left this one at `Info`.