### PR TITLE
Don't analyze generated code.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.2.1</VersionPrefix>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -9,6 +9,10 @@ Prefix the description of the change with `[major]`, `[minor]`, or `[patch]` in 
 New analyzers are considered "minor" changes (even though adding a new analyzer is likely to generate warnings
 or errors for existing code when the package is upgraded).
 
+## 1.2.1
+
+* Set flag in all analyzers to stop analyzing generated code.
+
 ## 1.2.0
 
 * Add `FL0012`: don't use interpolated string with `DbConnector.Command`: [#17](https://github.com/Faithlife/FaithlifeAnalyzers/issues/69).

--- a/src/Faithlife.Analyzers/AvailableWorkStateAnalyzer.cs
+++ b/src/Faithlife.Analyzers/AvailableWorkStateAnalyzer.cs
@@ -12,6 +12,8 @@ namespace Faithlife.Analyzers
 	{
 		public override void Initialize(AnalysisContext context)
 		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
 			context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
 			{
 				var iworkState = compilationStartAnalysisContext.Compilation.GetTypeByMetadataName("Libronix.Utility.Threading.IWorkState");

--- a/src/Faithlife.Analyzers/CurrentAsyncWorkItemAnalyzer.cs
+++ b/src/Faithlife.Analyzers/CurrentAsyncWorkItemAnalyzer.cs
@@ -12,6 +12,8 @@ namespace Faithlife.Analyzers
 	{
 		public override void Initialize(AnalysisContext context)
 		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
 			context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
 			{
 				var asyncWorkItem = compilationStartAnalysisContext.Compilation.GetTypeByMetadataName("Libronix.Utility.Threading.AsyncWorkItem");

--- a/src/Faithlife.Analyzers/DbConnectorCommandInterpolatedAnalyzer.cs
+++ b/src/Faithlife.Analyzers/DbConnectorCommandInterpolatedAnalyzer.cs
@@ -9,7 +9,10 @@ namespace Faithlife.Analyzers
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
 	public sealed class DbConnectorCommandInterpolatedAnalyzer : DiagnosticAnalyzer
 	{
-		public override void Initialize(AnalysisContext context) =>
+		public override void Initialize(AnalysisContext context)
+		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
 			context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
 			{
 				if (compilationStartAnalysisContext.Compilation.GetTypeByMetadataName("Faithlife.Data.DbConnector") is { } dbConnectorType)
@@ -29,6 +32,7 @@ namespace Faithlife.Analyzers
 					}, SyntaxKind.InvocationExpression);
 				}
 			});
+		}
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
 

--- a/src/Faithlife.Analyzers/EmptyStringAnalyzer.cs
+++ b/src/Faithlife.Analyzers/EmptyStringAnalyzer.cs
@@ -14,6 +14,8 @@ namespace Faithlife.Analyzers
 	{
 		public override void Initialize(AnalysisContext context)
 		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
 			context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
 			{
 				var stringClass = compilationStartAnalysisContext.Compilation.GetTypeByMetadataName("System.String");

--- a/src/Faithlife.Analyzers/GetOrAddValueAnalyzer.cs
+++ b/src/Faithlife.Analyzers/GetOrAddValueAnalyzer.cs
@@ -11,6 +11,8 @@ namespace Faithlife.Analyzers
 	{
 		public override void Initialize(AnalysisContext context)
 		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
 			context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
 			{
 				var dictionaryUtility = compilationStartAnalysisContext.Compilation.GetTypeByMetadataName("Libronix.Utility.DictionaryUtility");

--- a/src/Faithlife.Analyzers/IfNotNullAnalyzer.cs
+++ b/src/Faithlife.Analyzers/IfNotNullAnalyzer.cs
@@ -12,6 +12,8 @@ namespace Faithlife.Analyzers
 	{
 		public override void Initialize(AnalysisContext context)
 		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
 			context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
 			{
 				var ifNotNullExtensionMethodType = compilationStartAnalysisContext.Compilation.GetTypeByMetadataName("Libronix.Utility.IfNotNull.IfNotNullExtensionMethod");

--- a/src/Faithlife.Analyzers/InterpolatedStringAnalyzer.cs
+++ b/src/Faithlife.Analyzers/InterpolatedStringAnalyzer.cs
@@ -11,6 +11,8 @@ namespace Faithlife.Analyzers
 	{
 		public override void Initialize(AnalysisContext context)
 		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
 			context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
 			{
 				compilationStartAnalysisContext.RegisterOperationBlockStartAction(context =>

--- a/src/Faithlife.Analyzers/OverloadWithStringComparerAnalyzer.cs
+++ b/src/Faithlife.Analyzers/OverloadWithStringComparerAnalyzer.cs
@@ -11,6 +11,8 @@ namespace Faithlife.Analyzers
 	{
 		public override void Initialize(AnalysisContext context)
 		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
 			context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
 			{
 				var enumerableType = compilationStartAnalysisContext.Compilation.GetTypeByMetadataName("System.Linq.Enumerable");

--- a/src/Faithlife.Analyzers/OverloadWithStringComparisonAnalyzer.cs
+++ b/src/Faithlife.Analyzers/OverloadWithStringComparisonAnalyzer.cs
@@ -12,6 +12,8 @@ namespace Faithlife.Analyzers
 	{
 		public override void Initialize(AnalysisContext context)
 		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
 			// NOTE: some parts of this implementation derived from https://github.com/dotnet/roslyn-analyzers/blob/7a2540618fc32c5b38bdb43bc3a70ba6401ed135/src/Microsoft.NetCore.Analyzers/Core/Runtime/UseOrdinalStringComparison.cs
 			context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
 			{

--- a/src/Faithlife.Analyzers/ToReadOnlyCollectionAnalyzer.cs
+++ b/src/Faithlife.Analyzers/ToReadOnlyCollectionAnalyzer.cs
@@ -11,6 +11,8 @@ namespace Faithlife.Analyzers
 	{
 		public override void Initialize(AnalysisContext context)
 		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
 			context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
 			{
 				var enumerableUtility = compilationStartAnalysisContext.Compilation.GetTypeByMetadataName("Libronix.Utility.EnumerableUtility");

--- a/src/Faithlife.Analyzers/UntilCanceledAnalyzer.cs
+++ b/src/Faithlife.Analyzers/UntilCanceledAnalyzer.cs
@@ -13,6 +13,8 @@ namespace Faithlife.Analyzers
 	{
 		public override void Initialize(AnalysisContext context)
 		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
 			context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
 			{
 				var asyncEnumerableUtility = compilationStartAnalysisContext.Compilation.GetTypeByMetadataName("Libronix.Utility.Threading.AsyncEnumerableUtility");


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.diagnostics.analysiscontext.configuregeneratedcodeanalysis?view=roslyn-dotnet#Microsoft_CodeAnalysis_Diagnostics_AnalysisContext_ConfigureGeneratedCodeAnalysis_Microsoft_CodeAnalysis_Diagnostics_GeneratedCodeAnalysisFlags_

> It is recommended for the analyzer to invoke this API with the required `GeneratedCodeAnalysisFlags` setting.