### PR TITLE
Add analyzers for unnecessary interpolated/verbatim strings

### DIFF
--- a/src/Faithlife.Analyzers/AvailableWorkStateCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/AvailableWorkStateCodeFixProvider.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
@@ -54,9 +52,9 @@ namespace Faithlife.Analyzers
 				{
 					context.RegisterCodeFix(
 						CodeAction.Create(
-							title: $"Use AsyncWorkItem.Current",
+							title: "Use AsyncWorkItem.Current",
 							createChangedDocument: token => ReplaceValueAsync(context.Document, memberAccess, s_currentWorkItemExpression, token),
-							$"use-asyncworkitem-current"),
+							"use-asyncworkitem-current"),
 						diagnostic);
 				}
 			}

--- a/src/Faithlife.Analyzers/EmptyStringCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/EmptyStringCodeFixProvider.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
@@ -8,9 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Simplification;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Faithlife.Analyzers
@@ -36,9 +32,9 @@ namespace Faithlife.Analyzers
 
 			context.RegisterCodeFix(
 				CodeAction.Create(
-					title: $"Use \"\"",
+					title: "Use \"\"",
 					createChangedDocument: token => ReplaceValueAsync(context.Document, memberAccess, s_emptyStringExpression, token),
-					$"use-empty-string-literal"),
+					"use-empty-string-literal"),
 				diagnostic);
 		}
 

--- a/src/Faithlife.Analyzers/VerbatimStringAnalyzer.cs
+++ b/src/Faithlife.Analyzers/VerbatimStringAnalyzer.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace Faithlife.Analyzers
 {
@@ -27,18 +26,19 @@ namespace Faithlife.Analyzers
 		private static void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
 		{
 			var literalSyntax = (LiteralExpressionSyntax) context.Node;
-			var text = literalSyntax.Token.Text ?? "";
 
+			var text = literalSyntax.Token.Text ?? "";
 			if (!text.StartsWith("@", StringComparison.Ordinal))
 				return;
 
-			if (charsWhereVerbatimIsntUnnecessary.Any(text.Contains))
+			var valueText = literalSyntax.Token.ValueText ?? "";
+			if (valueText.IndexOfAny(c_charsWhereVerbatimIsntUnnecessary.ToCharArray()) != -1)
 				return;
 
 			context.ReportDiagnostic(Diagnostic.Create(s_rule, literalSyntax.GetLocation()));
 		}
 
-		private const string charsWhereVerbatimIsntUnnecessary = "\n\t\\";
+		private const string c_charsWhereVerbatimIsntUnnecessary = "\n\t\"\\";
 
 		private static readonly DiagnosticDescriptor s_rule = new(
 			id: DiagnosticId,

--- a/src/Faithlife.Analyzers/VerbatimStringAnalyzer.cs
+++ b/src/Faithlife.Analyzers/VerbatimStringAnalyzer.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Faithlife.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed class VerbatimStringAnalyzer : DiagnosticAnalyzer
+	{
+		public override void Initialize(AnalysisContext context)
+		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+			context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
+				compilationStartAnalysisContext.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.StringLiteralExpression));
+		}
+
+		public const string DiagnosticId = "FL0016";
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
+
+		private static void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
+		{
+			var literalSyntax = (LiteralExpressionSyntax) context.Node;
+			var text = literalSyntax.Token.Text ?? "";
+
+			if (!text.StartsWith("@", StringComparison.Ordinal))
+				return;
+
+			if (charsWhereVerbatimIsntUnnecessary.Any(text.Contains))
+				return;
+
+			context.ReportDiagnostic(Diagnostic.Create(s_rule, literalSyntax.GetLocation()));
+		}
+
+		private const string charsWhereVerbatimIsntUnnecessary = "\n\t\\";
+
+		private static readonly DiagnosticDescriptor s_rule = new(
+			id: DiagnosticId,
+			title: "Unnecessary use of verbatim string literal",
+			messageFormat: "Avoid using verbatim string literals without special characters.",
+			category: "Usage",
+			defaultSeverity: DiagnosticSeverity.Warning,
+			isEnabledByDefault: true,
+			helpLinkUri: $"https://github.com/Faithlife/FaithlifeAnalyzers/wiki/{DiagnosticId}");
+	}
+}

--- a/src/Faithlife.Analyzers/VerbatimStringAnalyzer.cs
+++ b/src/Faithlife.Analyzers/VerbatimStringAnalyzer.cs
@@ -38,7 +38,7 @@ namespace Faithlife.Analyzers
 			context.ReportDiagnostic(Diagnostic.Create(s_rule, literalSyntax.GetLocation()));
 		}
 
-		private const string c_charsWhereVerbatimIsntUnnecessary = "\n\t\"\\";
+		private const string c_charsWhereVerbatimIsntUnnecessary = "\n\"\\";
 
 		private static readonly DiagnosticDescriptor s_rule = new(
 			id: DiagnosticId,

--- a/tests/Faithlife.Analyzers.Tests/InterpolatedStringTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/InterpolatedStringTests.cs
@@ -60,7 +60,7 @@ namespace TestApplication
 }";
 			VerifyCSharpDiagnostic(invalidProgram, new DiagnosticResult
 			{
-				Id = InterpolatedStringAnalyzer.DiagnosticId,
+				Id = InterpolatedStringAnalyzer.DiagnosticIdDollar,
 				Message = "Avoid using ${} in interpolated strings.",
 				Severity = DiagnosticSeverity.Warning,
 				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 9, 20) },
@@ -85,14 +85,14 @@ namespace TestApplication
 			VerifyCSharpDiagnostic(invalidProgram,
 				new DiagnosticResult
 				{
-					Id = InterpolatedStringAnalyzer.DiagnosticId,
+					Id = InterpolatedStringAnalyzer.DiagnosticIdDollar,
 					Message = "Avoid using ${} in interpolated strings.",
 					Severity = DiagnosticSeverity.Warning,
 					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 9, 20) },
 				},
 				new DiagnosticResult
 				{
-					Id = InterpolatedStringAnalyzer.DiagnosticId,
+					Id = InterpolatedStringAnalyzer.DiagnosticIdDollar,
 					Message = "Avoid using ${} in interpolated strings.",
 					Severity = DiagnosticSeverity.Warning,
 					Locations = new[] { new DiagnosticResultLocation("Test0.cs", 9, 26) },
@@ -116,10 +116,56 @@ namespace TestApplication
 }";
 			VerifyCSharpDiagnostic(invalidProgram, new DiagnosticResult
 			{
-				Id = InterpolatedStringAnalyzer.DiagnosticId,
+				Id = InterpolatedStringAnalyzer.DiagnosticIdDollar,
 				Message = "Avoid using ${} in interpolated strings.",
 				Severity = DiagnosticSeverity.Warning,
 				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 9, 20) },
+			});
+		}
+
+		[Test]
+		public void UnnecessaryInterpolatedString()
+		{
+			const string invalidProgram = @"
+namespace TestApplication
+{
+	public class TestClass
+	{
+		public TestClass()
+		{
+			string str = $""Hello World"";
+		}
+	}
+}";
+			VerifyCSharpDiagnostic(invalidProgram, new DiagnosticResult
+			{
+				Id = InterpolatedStringAnalyzer.DiagnosticIdUnnecessary,
+				Message = "Avoid using an interpolated string where an equivalent literal string exists.",
+				Severity = DiagnosticSeverity.Warning,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 17) },
+			});
+		}
+
+		[Test]
+		public void EmptyInterpolatedString()
+		{
+			const string invalidProgram = @"
+namespace TestApplication
+{
+	public class TestClass
+	{
+		public TestClass()
+		{
+			string str = $"""";
+		}
+	}
+}";
+			VerifyCSharpDiagnostic(invalidProgram, new DiagnosticResult
+			{
+				Id = InterpolatedStringAnalyzer.DiagnosticIdUnnecessary,
+				Message = "Avoid using an interpolated string where an equivalent literal string exists.",
+				Severity = DiagnosticSeverity.Warning,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 17) },
 			});
 		}
 

--- a/tests/Faithlife.Analyzers.Tests/OverloadWithStringComparerTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/OverloadWithStringComparerTests.cs
@@ -54,7 +54,7 @@ namespace Faithlife.Analyzers.Tests
 		[Test]
 		public void OrderByIntegerWithoutComparer_Valid([Values] Ordering ordering)
 		{
-			string code = GetExtensionMethodCode(ordering, @"new[] { 3, 2, 1 }", "x => x");
+			string code = GetExtensionMethodCode(ordering, "new[] { 3, 2, 1 }", "x => x");
 			VerifyValidExpression(code);
 		}
 
@@ -68,7 +68,7 @@ namespace Faithlife.Analyzers.Tests
 		[Test]
 		public void ExplicitOrderByStringWithComparer_Valid()
 		{
-			VerifyValidExpression(@"Enumerable.OrderBy(new[] { 3, 2, 1 }, x => x.ToString(), StringComparer.CurrentCulture)");
+			VerifyValidExpression("Enumerable.OrderBy(new[] { 3, 2, 1 }, x => x.ToString(), StringComparer.CurrentCulture)");
 		}
 
 		[Test]
@@ -81,7 +81,7 @@ namespace Faithlife.Analyzers.Tests
 		[Test]
 		public void LinqSyntaxOrderByStringFromInteger_Invalid([Values] Ordering ordering)
 		{
-			string code = GetLinqSyntaxCode(ordering, @"new[] { 3, 2, 1 }", "x.ToString()");
+			string code = GetLinqSyntaxCode(ordering, "new[] { 3, 2, 1 }", "x.ToString()");
 			VerifyInvalidExpression(code, code.IndexOf("orderby", StringComparison.Ordinal));
 		}
 

--- a/tests/Faithlife.Analyzers.Tests/SelfAnalysisTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/SelfAnalysisTests.cs
@@ -29,7 +29,7 @@ namespace Faithlife.Analyzers.Tests
 				.WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
 				.AddMetadataReferences(projectId, s_metadataReferences);
 
-			foreach (var source in Directory.GetFiles(@"../../../../../src/Faithlife.Analyzers", "*.cs").Concat(Directory.GetFiles(@"../../../../../tests/Faithlife.Analyzers.Tests", "*.cs")))
+			foreach (var source in Directory.GetFiles("../../../../../src/Faithlife.Analyzers", "*.cs").Concat(Directory.GetFiles("../../../../../tests/Faithlife.Analyzers.Tests", "*.cs")))
 			{
 				var fileName = Path.GetFileName(source);
 				var documentId = DocumentId.CreateNewId(projectId, debugName: fileName);

--- a/tests/Faithlife.Analyzers.Tests/VerbatimStringTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/VerbatimStringTests.cs
@@ -17,11 +17,11 @@ namespace TestApplication
 	{
 		public TestClass()
 		{
-			@""Hello	World"".Trim();
 			@""Hello
 World"".Trim();
 			@""Hello\World"".Trim();
 			""Hello World"".Trim();
+			@""Hello """"wait for it"""" World"".Trim();
 		}
 	}
 }";

--- a/tests/Faithlife.Analyzers.Tests/VerbatimStringTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/VerbatimStringTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Framework;
+
+namespace Faithlife.Analyzers.Tests
+{
+	[TestFixture]
+	public sealed class VerbatimStringTests : DiagnosticVerifier
+	{
+		[Test]
+		public void ValidStrings()
+		{
+			const string validProgram = @"
+namespace TestApplication
+{
+	public class TestClass
+	{
+		public TestClass()
+		{
+			@""Hello	World"".Trim();
+			@""Hello
+World"".Trim();
+			@""Hello\World"".Trim();
+			""Hello World"".Trim();
+		}
+	}
+}";
+			VerifyCSharpDiagnostic(validProgram);
+		}
+
+		[Test]
+		public void UnnecessaryVerbatimString()
+		{
+			const string invalidProgram = @"
+namespace TestApplication
+{
+	public class TestClass
+	{
+		public TestClass()
+		{
+			@""Hello World"".Trim();
+		}
+	}
+}";
+			VerifyCSharpDiagnostic(invalidProgram, new DiagnosticResult
+			{
+				Id = VerbatimStringAnalyzer.DiagnosticId,
+				Message = "Avoid using verbatim string literals without special characters.",
+				Severity = DiagnosticSeverity.Warning,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 4) },
+			});
+		}
+
+		[Test]
+		public void EmptyString()
+		{
+			const string invalidProgram = @"
+namespace TestApplication
+{
+	public class TestClass
+	{
+		public TestClass()
+		{
+			@"""".Trim();
+		}
+	}
+}";
+			VerifyCSharpDiagnostic(invalidProgram, new DiagnosticResult
+			{
+				Id = VerbatimStringAnalyzer.DiagnosticId,
+				Message = "Avoid using verbatim string literals without special characters.",
+				Severity = DiagnosticSeverity.Warning,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 4) },
+			});
+		}
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new VerbatimStringAnalyzer();
+	}
+}


### PR DESCRIPTION
This PR resolves #63 by adding another diagnostic to the `InterpolatedStringAnalyzer` and adding a new `VerbatimStringAnalyzer`.

