### PR TITLE
Prefer null conditional over ternaries

### DIFF
--- a/src/Faithlife.Analyzers/NullTestTernariesAnalyzer.cs
+++ b/src/Faithlife.Analyzers/NullTestTernariesAnalyzer.cs
@@ -1,0 +1,53 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Faithlife.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed class NullTestTernariesAnalyzer : DiagnosticAnalyzer
+	{
+		public override void Initialize(AnalysisContext context)
+		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+			context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
+			{
+				compilationStartAnalysisContext.RegisterSyntaxNodeAction(c => AnalyzeSyntax(c), SyntaxKind.ConditionalExpression);
+			});
+		}
+
+		private static void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
+		{
+			var expression = (ConditionalExpressionSyntax) context.Node;
+			var falseValue = expression.WhenFalse;
+			var trueValue = expression.WhenTrue;
+
+			var eExpression = (BinaryExpressionSyntax) expression.Condition;
+
+			var lExpression = eExpression.Left;
+			var rExpression = eExpression.Right;
+
+			if ((falseValue.Kind() == SyntaxKind.NullLiteralExpression || trueValue.Kind() == SyntaxKind.NullLiteralExpression) && (lExpression.Kind() == SyntaxKind.NullLiteralExpression || rExpression.Kind() == SyntaxKind.NullLiteralExpression))
+			{
+				context.ReportDiagnostic(Diagnostic.Create(s_rule, expression.GetLocation()));
+			}
+		}
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
+
+		public const string DiagnosticId = "FL0015";
+
+		private static readonly DiagnosticDescriptor s_rule = new(
+			id: DiagnosticId,
+			title: "Null Checking Ternaries Usage",
+			messageFormat: "Prefer null conditional operators over ternaries explicitly checking for null",
+			category: "Usage",
+			defaultSeverity: DiagnosticSeverity.Warning,
+			isEnabledByDefault: true,
+			helpLinkUri: $"https://github.com/Faithlife/FaithlifeAnalyzers/wiki/{DiagnosticId}"
+		);
+	}
+}

--- a/src/Faithlife.Analyzers/NullTestTernariesAnalyzer.cs
+++ b/src/Faithlife.Analyzers/NullTestTernariesAnalyzer.cs
@@ -25,14 +25,22 @@ namespace Faithlife.Analyzers
 			var falseValue = expression.WhenFalse;
 			var trueValue = expression.WhenTrue;
 
-			var eExpression = (BinaryExpressionSyntax) expression.Condition;
-
-			var lExpression = eExpression.Left;
-			var rExpression = eExpression.Right;
-
-			if ((falseValue.Kind() == SyntaxKind.NullLiteralExpression || trueValue.Kind() == SyntaxKind.NullLiteralExpression) && (lExpression.Kind() == SyntaxKind.NullLiteralExpression || rExpression.Kind() == SyntaxKind.NullLiteralExpression))
+			if (expression.Condition is BinaryExpressionSyntax binaryExpression)
 			{
-				context.ReportDiagnostic(Diagnostic.Create(s_rule, expression.GetLocation()));
+				var lExpression = binaryExpression.Left;
+				var rExpression = binaryExpression.Right;
+
+				if ((falseValue.Kind() == SyntaxKind.NullLiteralExpression || trueValue.Kind() == SyntaxKind.NullLiteralExpression) && (lExpression.Kind() == SyntaxKind.NullLiteralExpression || rExpression.Kind() == SyntaxKind.NullLiteralExpression))
+				{
+					context.ReportDiagnostic(Diagnostic.Create(s_rule, expression.GetLocation()));
+				}
+			}
+			else if (expression.Condition is MemberAccessExpressionSyntax memberAccessExpression)
+			{
+				if (memberAccessExpression.Kind() == SyntaxKind.SimpleMemberAccessExpression && memberAccessExpression.Name.Identifier.Text == "HasValue")
+				{
+					context.ReportDiagnostic(Diagnostic.Create(s_rule, expression.GetLocation()));
+				}
 			}
 		}
 

--- a/tests/Faithlife.Analyzers.Tests/NullTestTernariesTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/NullTestTernariesTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Framework;
+
+namespace Faithlife.Analyzers.Tests
+{
+	[TestFixture]
+	public class NullTestTernariesTests : CodeFixVerifier
+	{
+		[Test]
+		public void ValidUsage()
+		{
+			const string validProgram = c_preamble + @"
+namespace TestApplication
+{
+	public class Person
+	{
+		public string FirstName { get; set; }
+		public string LastName { get; set; }
+	}
+
+	internal static class TestClass
+	{
+		public static void UtilityMethod()
+		{
+			Person person = null;
+			var firstName = person?.FirstName;
+		}
+	}
+}";
+
+			VerifyCSharpDiagnostic(validProgram);
+		}
+
+		[TestCase("var firstName = person != null ? person.FirstName : null;")]
+		[TestCase("var firstName = person == null ? null : person.FirstName;")]
+		public void InvalidUsage(string badExample)
+		{
+			var brokenProgram = c_preamble + $@"
+namespace TestApplication
+{{
+	public class Person
+	{{
+		public string? FirstName {{ get; set; }}
+		public string? LastName {{ get; set; }}
+	}}
+
+	internal static class TestClass
+	{{
+		public static void UtilityMethod()
+		{{
+			Person person = null;
+			{badExample}
+		}}
+	}}
+}}";
+
+			var expected = new DiagnosticResult
+			{
+				Id = NullTestTernariesAnalyzer.DiagnosticId,
+				Message = "Prefer null conditional operators over ternaries explicitly checking for null",
+				Severity = DiagnosticSeverity.Warning,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", s_preambleLength + 15, 20) },
+			};
+
+			VerifyCSharpDiagnostic(brokenProgram, expected);
+		}
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new NullTestTernariesAnalyzer();
+
+		private const string c_preamble = @"";
+
+		private static readonly int s_preambleLength = c_preamble.Split('\n').Length;
+	}
+}

--- a/tests/Faithlife.Analyzers.Tests/NullTestTernariesTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/NullTestTernariesTests.cs
@@ -32,8 +32,9 @@ namespace TestApplication
 			VerifyCSharpDiagnostic(validProgram);
 		}
 
-		[TestCase("var firstName = person != null ? person.FirstName : null;")]
-		[TestCase("var firstName = person == null ? null : person.FirstName;")]
+		[TestCase("var firstName = person.Age != null ? person.FirstName : null;")]
+		[TestCase("var firstName = person.Age == null ? null : person.FirstName;")]
+		[TestCase("var firstName = person.Age.HasValue ? person.FirstName : null;")]
 		public void InvalidUsage(string badExample)
 		{
 			var brokenProgram = c_preamble + $@"
@@ -41,15 +42,16 @@ namespace TestApplication
 {{
 	public class Person
 	{{
-		public string? FirstName {{ get; set; }}
-		public string? LastName {{ get; set; }}
+		public string FirstName {{ get; set; }}
+		public string LastName {{ get; set; }}
+		public int? Age {{ get; set; }}
 	}}
 
 	internal static class TestClass
 	{{
 		public static void UtilityMethod()
 		{{
-			Person person = null;
+			var person = new Person {{ FirstName = ""Bob"", LastName = ""Dole"" }};
 			{badExample}
 		}}
 	}}


### PR DESCRIPTION
This PR hopes to resolve #57 by checking for null values / checks in ternary statements, as well as looking for HasValue, and requesting the user instead do a null conditional operator for cleaner code.