### PR TITLE
Add NumericConstantAssignmentAnalyzer

### DIFF
--- a/src/Faithlife.Analyzers/NumericConstantAssignmentAnalyzer.cs
+++ b/src/Faithlife.Analyzers/NumericConstantAssignmentAnalyzer.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Xml;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Faithlife.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed class NumericConstantAssignmentAnalyzer : DiagnosticAnalyzer
+	{
+		public override void Initialize(AnalysisContext context)
+		{
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+			context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
+				compilationStartAnalysisContext.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.FieldDeclaration));
+		}
+
+		public const string DiagnosticId = "FL0017";
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
+
+		private static bool IsTimeRelatedExpression(ExpressionSyntax expression)
+		{
+			if (expression is LiteralExpressionSyntax literal)
+				return literal.Token.Value is int intValue && s_commonTimeRelatedConstants.Contains(intValue);
+
+			if (expression is BinaryExpressionSyntax binaryExpression && binaryExpression.IsKind(SyntaxKind.MultiplyExpression))
+				return IsTimeRelatedExpression(binaryExpression.Left) && IsTimeRelatedExpression(binaryExpression.Right);
+
+			return false;
+		}
+
+		private static void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
+		{
+			var fieldDeclarationSyntax = (FieldDeclarationSyntax) context.Node;
+
+			var isConstDeclaration = fieldDeclarationSyntax.Modifiers.Any(token=>token.IsKind(SyntaxKind.ConstKeyword));
+			if (!isConstDeclaration)
+				return;
+
+			var declarations = fieldDeclarationSyntax.Declaration.Variables;
+			foreach (var declaratorSyntax in declarations)
+			{
+				var initializerValue = declaratorSyntax.Initializer.Value;
+				if (IsTimeRelatedExpression(initializerValue))
+					context.ReportDiagnostic(Diagnostic.Create(s_rule, initializerValue.GetLocation()));
+			}
+		}
+
+		private static readonly List<int> s_commonTimeRelatedConstants = new() { 365, 60, 31, 30, 28, 24, 7 };
+
+		private static readonly DiagnosticDescriptor s_rule = new(
+			id: DiagnosticId,
+			title: "Avoid common date/time constants",
+			messageFormat: "Avoid creating constants for date/time operations; consider using a library instead.",
+			category: "Usage",
+			defaultSeverity: DiagnosticSeverity.Warning,
+			isEnabledByDefault: true,
+			helpLinkUri: $"https://github.com/Faithlife/FaithlifeAnalyzers/wiki/{DiagnosticId}");
+	}
+}

--- a/tests/Faithlife.Analyzers.Tests/NumericConstantAssignmentTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/NumericConstantAssignmentTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Framework;
+
+namespace Faithlife.Analyzers.Tests
+{
+	[TestFixture]
+	public sealed class NumericConstantAssignmentTests : DiagnosticVerifier
+	{
+		[Test]
+		public void ValidAssignments()
+		{
+			const string validProgram = @"
+namespace TestApplication
+{
+	public class TestClass
+	{
+		private const int a = 14;
+		const int b = 3;
+		private const double c = 7.0;
+		const double d = 14;
+		const string s = ""Hello World"";
+		const int m = 5 * 5 * 7;
+		const int n = 24 - 7;
+		const int p = 365 / 7;
+		}
+}";
+			VerifyCSharpDiagnostic(validProgram);
+		}
+
+		[TestCase("private const int x", "24")]
+		[TestCase("const int x", "7")]
+		[TestCase("private const double x", "60")]
+		[TestCase("const double x", "60 * 60")]
+		[TestCase("private const int x", "60 * 60 * 24")]
+		public void InvalidUsage(string declaration, string expression)
+		{
+			var brokenProgram = $@"
+namespace TestApplication
+{{
+	internal static class TestClass
+	{{
+		{declaration} = {expression};
+	}}
+}}";
+			VerifyCSharpDiagnostic(brokenProgram, new DiagnosticResult
+			{
+				Id = NumericConstantAssignmentAnalyzer.DiagnosticId,
+				Message = "Avoid creating constants for date/time operations; consider using a library instead.",
+				Severity = DiagnosticSeverity.Warning,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, declaration.Length + 6) },
+			});
+		}
+
+		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new NumericConstantAssignmentAnalyzer();
+	}
+}


### PR DESCRIPTION
This analyzer checks assignments to `const` fields and throws a warning if the value being assigned is an integer commonly used for date/time math, or a product of such integers. This should resolve #65.