### PR TITLE
Fix crash in `UriToStringAnalyzer`

### DIFF
--- a/src/Faithlife.Analyzers/UriToStringAnalyzer.cs
+++ b/src/Faithlife.Analyzers/UriToStringAnalyzer.cs
@@ -31,9 +31,14 @@ namespace Faithlife.Analyzers
 			if (method?.Name != "ToString" || method.ContainingType != uriType)
 				return;
 
-			var memberAccess = (MemberAccessExpressionSyntax) invocation.Expression;
+			var location = invocation.Expression switch
+			{
+				MemberAccessExpressionSyntax memberAccess => memberAccess.Name.GetLocation(),
+				MemberBindingExpressionSyntax memberBinding => memberBinding.Name.GetLocation(),
+				_ => null,
+			};
 
-			context.ReportDiagnostic(Diagnostic.Create(s_rule, memberAccess.Name.GetLocation()));
+			context.ReportDiagnostic(Diagnostic.Create(s_rule, location));
 		}
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);

--- a/tests/Faithlife.Analyzers.Tests/UriToStringTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/UriToStringTests.cs
@@ -51,6 +51,32 @@ namespace TestApplication
 			VerifyCSharpDiagnostic(brokenProgram, expected);
 		}
 
+		[Test]
+		public void InvalidNullableUsage()
+		{
+			var brokenProgram = @"
+namespace TestApplication
+{
+	internal static class TestClass
+	{
+		public static void UtilityMethod(System.Uri uri)
+		{
+			var x = uri?.ToString();
+		}
+	}
+}";
+
+			var expected = new DiagnosticResult
+			{
+				Id = UriToStringAnalyzer.DiagnosticId,
+				Message = "Do not use Uri.ToString()",
+				Severity = DiagnosticSeverity.Warning,
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 17) },
+			};
+
+			VerifyCSharpDiagnostic(brokenProgram, expected);
+		}
+
 		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new UriToStringAnalyzer();
 	}
 }


### PR DESCRIPTION
The analyzer can't handle a member binding expression.