### PR TITLE
Improve performance of analyzers

### DIFF
--- a/src/Faithlife.Analyzers/AvailableWorkStateAnalyzer.cs
+++ b/src/Faithlife.Analyzers/AvailableWorkStateAnalyzer.cs
@@ -44,14 +44,6 @@ namespace Faithlife.Analyzers
 		{
 			var syntax = (MemberAccessExpressionSyntax)context.Node;
 
-			var symbolInfo = context.SemanticModel.GetSymbolInfo(syntax.Expression);
-			if (symbolInfo.Symbol == null || !symbolInfo.Symbol.Equals(workStateClass))
-				return;
-
-			var memberSymbolInfo = context.SemanticModel.GetSymbolInfo(syntax.Name);
-			if (memberSymbolInfo.Symbol == null || (!memberSymbolInfo.Symbol.Equals(workStateNone) && !memberSymbolInfo.Symbol.Equals(workStateToDo)))
-				return;
-
 			var containingMethod = syntax.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
 			if (containingMethod == null)
 				return;
@@ -68,6 +60,14 @@ namespace Faithlife.Analyzers
 					return;
 				}
 			}
+
+			var symbolInfo = context.SemanticModel.GetSymbolInfo(syntax.Expression);
+			if (symbolInfo.Symbol == null || !symbolInfo.Symbol.Equals(workStateClass))
+				return;
+
+			var memberSymbolInfo = context.SemanticModel.GetSymbolInfo(syntax.Name);
+			if (memberSymbolInfo.Symbol == null || (!memberSymbolInfo.Symbol.Equals(workStateNone) && !memberSymbolInfo.Symbol.Equals(workStateToDo)))
+				return;
 
 			var cancellationToken = context.SemanticModel.Compilation.GetTypeByMetadataName("System.Threading.CancellationToken");
 			var asyncMethodContext = context.SemanticModel.Compilation.GetTypeByMetadataName("Libronix.Utility.Threading.AsyncMethodContext");

--- a/src/Faithlife.Analyzers/CurrentAsyncWorkItemAnalyzer.cs
+++ b/src/Faithlife.Analyzers/CurrentAsyncWorkItemAnalyzer.cs
@@ -40,14 +40,6 @@ namespace Faithlife.Analyzers
 		{
 			var syntax = (MemberAccessExpressionSyntax) context.Node;
 
-			var symbolInfo = context.SemanticModel.GetSymbolInfo(syntax.Expression);
-			if (symbolInfo.Symbol == null || !symbolInfo.Symbol.Equals(asyncWorkItem))
-				return;
-
-			var memberSymbolInfo = context.SemanticModel.GetSymbolInfo(syntax.Name);
-			if (memberSymbolInfo.Symbol == null || !memberSymbolInfo.Symbol.Equals(asyncWorkItemCurrent))
-				return;
-
 			var containingMethod = syntax.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
 			if (containingMethod == null)
 				return;
@@ -59,6 +51,14 @@ namespace Faithlife.Analyzers
 			{
 				return;
 			}
+
+			var symbolInfo = context.SemanticModel.GetSymbolInfo(syntax.Expression);
+			if (symbolInfo.Symbol == null || !symbolInfo.Symbol.Equals(asyncWorkItem))
+				return;
+
+			var memberSymbolInfo = context.SemanticModel.GetSymbolInfo(syntax.Name);
+			if (memberSymbolInfo.Symbol == null || !memberSymbolInfo.Symbol.Equals(asyncWorkItemCurrent))
+				return;
 
 			// check for AsyncWorkItem.Current being used in a lambda passed as an argument to AsyncWorkItem.Start
 			var invocation = syntax.FirstAncestorOrSelf<LambdaExpressionSyntax>()?.FirstAncestorOrSelf<ArgumentSyntax>()?.FirstAncestorOrSelf<InvocationExpressionSyntax>();

--- a/src/Faithlife.Analyzers/EmptyStringAnalyzer.cs
+++ b/src/Faithlife.Analyzers/EmptyStringAnalyzer.cs
@@ -38,6 +38,9 @@ namespace Faithlife.Analyzers
 		{
 			var syntax = (MemberAccessExpressionSyntax)context.Node;
 
+			if (syntax.Name.Identifier.Text != "Empty")
+				return;
+
 			var symbolInfo = context.SemanticModel.GetSymbolInfo(syntax.Name);
 			if (symbolInfo.Symbol == null || !symbolInfo.Symbol.Equals(emptyString))
 				return;

--- a/src/Faithlife.Analyzers/UntilCanceledAnalyzer.cs
+++ b/src/Faithlife.Analyzers/UntilCanceledAnalyzer.cs
@@ -39,8 +39,18 @@ namespace Faithlife.Analyzers
 			{
 				var invocation = (InvocationExpressionSyntax) context.Node;
 
+				var name = invocation.Expression switch
+				{
+					MemberAccessExpressionSyntax memberAccess => memberAccess.Name,
+					MemberBindingExpressionSyntax memberBinding => memberBinding.Name,
+					_ => null,
+				};
+
+				if (name?.Identifier.Text != "UntilCanceled")
+					return;
+
 				var method = context.SemanticModel.GetSymbolInfo(invocation.Expression).Symbol as IMethodSymbol;
-				if (method?.Name != "UntilCanceled" || method.ContainingType != asyncEnumerableUtility)
+				if (method?.ContainingType != asyncEnumerableUtility)
 					return;
 
 				if (invocation.ArgumentList.Arguments.Count != 0)

--- a/tests/Faithlife.Analyzers.Tests/UriToStringTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/UriToStringTests.cs
@@ -45,7 +45,7 @@ namespace TestApplication
 				Id = UriToStringAnalyzer.DiagnosticId,
 				Message = "Do not use Uri.ToString()",
 				Severity = DiagnosticSeverity.Warning,
-				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 55) },
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 12) },
 			};
 
 			VerifyCSharpDiagnostic(brokenProgram, expected);
@@ -71,7 +71,7 @@ namespace TestApplication
 				Id = UriToStringAnalyzer.DiagnosticId,
 				Message = "Do not use Uri.ToString()",
 				Severity = DiagnosticSeverity.Warning,
-				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 17) },
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 16) },
 			};
 
 			VerifyCSharpDiagnostic(brokenProgram, expected);


### PR DESCRIPTION
Per https://github.com/dotnet/efcore/issues/18618#issuecomment-547187638, `RegisterOperationAction` is recommended over `GetSymbolInfo`.

Instead of rewriting all the analyzers, I simply modified some to perform a quick check (and early out) before invoking that expensive method.