### PR TITLE
Update Microsoft.CodeAnalysis.CSharp.Workspaces to 3.5.0.

### DIFF
--- a/src/Faithlife.Analyzers/AvailableWorkStateAnalyzer.cs
+++ b/src/Faithlife.Analyzers/AvailableWorkStateAnalyzer.cs
@@ -44,7 +44,7 @@ public sealed class AvailableWorkStateAnalyzer : DiagnosticAnalyzer
 	private static void AnalyzeOperation(OperationAnalysisContext context, INamedTypeSymbol iworkState, ISymbol workStateNone, ISymbol workStateToDo)
 	{
 		var propertyReferenceOperation = (IPropertyReferenceOperation) context.Operation;
-		if (!propertyReferenceOperation.Property.Equals(workStateNone) && !propertyReferenceOperation.Property.Equals(workStateToDo))
+		if (!SymbolEqualityComparer.Default.Equals(propertyReferenceOperation.Property, workStateNone) && !SymbolEqualityComparer.Default.Equals(propertyReferenceOperation.Property, workStateToDo))
 			return;
 
 		var syntax = (MemberAccessExpressionSyntax) propertyReferenceOperation.Syntax;
@@ -58,7 +58,7 @@ public sealed class AvailableWorkStateAnalyzer : DiagnosticAnalyzer
 		var asyncAction = context.Compilation.GetTypeByMetadataName("Libronix.Utility.Threading.AsyncAction");
 		var ienumerable = context.Compilation.GetTypeByMetadataName("System.Collections.Generic.IEnumerable`1");
 		var returnTypeSymbol = semanticModel.GetSymbolInfo(containingMethod.ReturnType).Symbol as INamedTypeSymbol;
-		var returnsIEnumerableAsyncAction = ienumerable?.Equals(returnTypeSymbol?.ConstructedFrom) is true && asyncAction?.Equals(returnTypeSymbol.TypeArguments[0]) is true;
+		var returnsIEnumerableAsyncAction = SymbolEqualityComparer.Default.Equals(ienumerable, returnTypeSymbol?.ConstructedFrom) && SymbolEqualityComparer.Default.Equals(asyncAction, returnTypeSymbol.TypeArguments[0]);
 		if (returnsIEnumerableAsyncAction)
 		{
 			context.ReportDiagnostic(Diagnostic.Create(s_rule, syntax.GetLocation()));
@@ -73,17 +73,17 @@ public sealed class AvailableWorkStateAnalyzer : DiagnosticAnalyzer
 			if (parameterSymbolInfo.Symbol is null)
 				return false;
 
-			if (parameterSymbolInfo.Symbol.Equals(iworkState))
+			if (SymbolEqualityComparer.Default.Equals(parameterSymbolInfo.Symbol, iworkState))
 				return true;
 
 			var namedTypeSymbol = parameterSymbolInfo.Symbol as INamedTypeSymbol;
 			if (namedTypeSymbol is null)
 				return false;
 
-			if (namedTypeSymbol.Equals(iworkState) || namedTypeSymbol.Equals(cancellationToken) || namedTypeSymbol.Equals(asyncMethodContext))
+			if (SymbolEqualityComparer.Default.Equals(namedTypeSymbol, iworkState) || SymbolEqualityComparer.Default.Equals(namedTypeSymbol, cancellationToken) || SymbolEqualityComparer.Default.Equals(namedTypeSymbol, asyncMethodContext))
 				return true;
 
-			return namedTypeSymbol.AllInterfaces.Any(x => x.Equals(iworkState));
+			return namedTypeSymbol.AllInterfaces.Any(x => SymbolEqualityComparer.Default.Equals(x, iworkState));
 		});
 
 		if (!hasWorkStateParameters)

--- a/src/Faithlife.Analyzers/AvailableWorkStateCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/AvailableWorkStateCodeFixProvider.cs
@@ -47,8 +47,8 @@ public class AvailableWorkStateCodeFixProvider : CodeFixProvider
 		{
 			var ienumerable = semanticModel.Compilation.GetTypeByMetadataName("System.Collections.Generic.IEnumerable`1");
 			var returnTypeSymbol = semanticModel.GetSymbolInfo(containingMethod.ReturnType).Symbol as INamedTypeSymbol;
-			if (returnTypeSymbol != null && returnTypeSymbol.ConstructedFrom != null && returnTypeSymbol.ConstructedFrom.Equals(ienumerable) &&
-				returnTypeSymbol.TypeArguments[0].Equals(asyncAction))
+			if (returnTypeSymbol != null && returnTypeSymbol.ConstructedFrom != null && SymbolEqualityComparer.Default.Equals(returnTypeSymbol.ConstructedFrom, ienumerable) &&
+				SymbolEqualityComparer.Default.Equals(returnTypeSymbol.TypeArguments[0], asyncAction))
 			{
 				context.RegisterCodeFix(
 					CodeAction.Create(
@@ -66,7 +66,7 @@ public class AvailableWorkStateCodeFixProvider : CodeFixProvider
 			if (symbolInfo.Symbol is null)
 				continue;
 
-			if (symbolInfo.Symbol.Equals(iworkState) || (symbolInfo.Symbol is INamedTypeSymbol namedTypeSymbol && namedTypeSymbol.AllInterfaces.Any(x => x.Equals(iworkState))))
+			if (SymbolEqualityComparer.Default.Equals(symbolInfo.Symbol, iworkState) || (symbolInfo.Symbol is INamedTypeSymbol namedTypeSymbol && namedTypeSymbol.AllInterfaces.Any(x => SymbolEqualityComparer.Default.Equals(x, iworkState))))
 			{
 				context.RegisterCodeFix(
 					CodeAction.Create(
@@ -75,7 +75,7 @@ public class AvailableWorkStateCodeFixProvider : CodeFixProvider
 						$"use-{parameter.Identifier.Text}"),
 					diagnostic);
 			}
-			else if (symbolInfo.Symbol.Equals(cancellationToken))
+			else if (SymbolEqualityComparer.Default.Equals(symbolInfo.Symbol, cancellationToken))
 			{
 				context.RegisterCodeFix(
 					CodeAction.Create(
@@ -88,7 +88,7 @@ public class AvailableWorkStateCodeFixProvider : CodeFixProvider
 						$"use-{parameter.Identifier.Text}"),
 					diagnostic);
 			}
-			else if (symbolInfo.Symbol.Equals(asyncMethodContext))
+			else if (SymbolEqualityComparer.Default.Equals(symbolInfo.Symbol, asyncMethodContext))
 			{
 				context.RegisterCodeFix(
 					CodeAction.Create(

--- a/src/Faithlife.Analyzers/CurrentAsyncWorkItemAnalyzer.cs
+++ b/src/Faithlife.Analyzers/CurrentAsyncWorkItemAnalyzer.cs
@@ -47,18 +47,18 @@ public sealed class CurrentAsyncWorkItemAnalyzer : DiagnosticAnalyzer
 
 		var ienumerable = context.SemanticModel.Compilation.GetTypeByMetadataName("System.Collections.Generic.IEnumerable`1");
 		var returnTypeSymbol = context.SemanticModel.GetSymbolInfo(containingMethod.ReturnType).Symbol as INamedTypeSymbol;
-		if (returnTypeSymbol != null && returnTypeSymbol.ConstructedFrom != null && returnTypeSymbol.ConstructedFrom.Equals(ienumerable) &&
-			returnTypeSymbol.TypeArguments[0].Equals(asyncAction))
+		if (returnTypeSymbol != null && returnTypeSymbol.ConstructedFrom != null && SymbolEqualityComparer.Default.Equals(returnTypeSymbol.ConstructedFrom, ienumerable) &&
+			SymbolEqualityComparer.Default.Equals(returnTypeSymbol.TypeArguments[0], asyncAction))
 		{
 			return;
 		}
 
 		var symbolInfo = context.SemanticModel.GetSymbolInfo(syntax.Expression);
-		if (symbolInfo.Symbol == null || !symbolInfo.Symbol.Equals(asyncWorkItem))
+		if (symbolInfo.Symbol == null || !SymbolEqualityComparer.Default.Equals(symbolInfo.Symbol, asyncWorkItem))
 			return;
 
 		var memberSymbolInfo = context.SemanticModel.GetSymbolInfo(syntax.Name);
-		if (memberSymbolInfo.Symbol == null || !memberSymbolInfo.Symbol.Equals(asyncWorkItemCurrent))
+		if (memberSymbolInfo.Symbol == null || !SymbolEqualityComparer.Default.Equals(memberSymbolInfo.Symbol, asyncWorkItemCurrent))
 			return;
 
 		// check for AsyncWorkItem.Current being used in a lambda passed as an argument to AsyncWorkItem.Start
@@ -68,7 +68,7 @@ public sealed class CurrentAsyncWorkItemAnalyzer : DiagnosticAnalyzer
 			if (memberAccess.Name.Identifier.Text == "Start")
 			{
 				symbolInfo = context.SemanticModel.GetSymbolInfo(memberAccess.Expression);
-				if (symbolInfo.Symbol.Equals(asyncWorkItem))
+				if (SymbolEqualityComparer.Default.Equals(symbolInfo.Symbol, asyncWorkItem))
 					return;
 			}
 		}

--- a/src/Faithlife.Analyzers/CurrentAsyncWorkItemCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/CurrentAsyncWorkItemCodeFixProvider.cs
@@ -49,14 +49,14 @@ public class CurrentAsyncWorkItemCodeFixProvider : CodeFixProvider
 			if (symbolInfo.Symbol is null)
 				return false;
 
-			if (symbolInfo.Symbol.Equals(iworkState))
+			if (SymbolEqualityComparer.Default.Equals(symbolInfo.Symbol, iworkState))
 				return true;
 
 			var namedTypeSymbol = symbolInfo.Symbol as INamedTypeSymbol;
 			if (namedTypeSymbol is null)
 				return false;
 
-			return namedTypeSymbol.AllInterfaces.Any(x => x.Equals(iworkState));
+			return namedTypeSymbol.AllInterfaces.Any(x => SymbolEqualityComparer.Default.Equals(x, iworkState));
 		});
 
 		foreach (var parameter in workStateParameters)

--- a/src/Faithlife.Analyzers/DbConnectorCommandInterpolatedAnalyzer.cs
+++ b/src/Faithlife.Analyzers/DbConnectorCommandInterpolatedAnalyzer.cs
@@ -22,7 +22,7 @@ public sealed class DbConnectorCommandInterpolatedAnalyzer : DiagnosticAnalyzer
 				{
 					if (syntaxNodeAnalysisContext.Node is InvocationExpressionSyntax invocation &&
 						syntaxNodeAnalysisContext.SemanticModel.GetSymbolInfo(invocation.Expression).Symbol is IMethodSymbol method &&
-						Equals(method.ContainingType, dbConnectorType) &&
+						SymbolEqualityComparer.Default.Equals(method.ContainingType, dbConnectorType) &&
 						method.Name == "Command" &&
 						method.Parameters.Length != 0 &&
 						method.Parameters[0].Type.SpecialType == SpecialType.System_String &&

--- a/src/Faithlife.Analyzers/EmptyStringAnalyzer.cs
+++ b/src/Faithlife.Analyzers/EmptyStringAnalyzer.cs
@@ -34,7 +34,7 @@ public sealed class EmptyStringAnalyzer : DiagnosticAnalyzer
 	private static void AnalyzeOperation(OperationAnalysisContext context, ISymbol emptyString)
 	{
 		var fieldReferenceOperation = (IFieldReferenceOperation) context.Operation;
-		if (!fieldReferenceOperation.Field.Equals(emptyString))
+		if (!SymbolEqualityComparer.Default.Equals(fieldReferenceOperation.Field, emptyString))
 			return;
 
 		context.ReportDiagnostic(Diagnostic.Create(s_rule, context.Operation.Syntax.GetLocation()));

--- a/src/Faithlife.Analyzers/Faithlife.Analyzers.csproj
+++ b/src/Faithlife.Analyzers/Faithlife.Analyzers.csproj
@@ -6,12 +6,12 @@
     <PackageTags>roslyn;analyzer</PackageTags>
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <NoWarn>$(NoWarn);NU5128;RS2008</NoWarn>
+    <NoWarn>$(NoWarn);NU5128;RS2008;CS8600;CS8602;CS8604;CS8619;CS8631</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.2.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Faithlife.Analyzers/GetOrAddValueAnalyzer.cs
+++ b/src/Faithlife.Analyzers/GetOrAddValueAnalyzer.cs
@@ -45,7 +45,7 @@ public sealed class GetOrAddValueAnalyzer : DiagnosticAnalyzer
 			return;
 
 		var method = context.SemanticModel.GetSymbolInfo(invocation.Expression).Symbol as IMethodSymbol;
-		if (!Equals(method?.ContainingType, dictionaryUtility))
+		if (!SymbolEqualityComparer.Default.Equals(method?.ContainingType, dictionaryUtility))
 			return;
 
 		var target = invocation.Expression switch
@@ -55,7 +55,7 @@ public sealed class GetOrAddValueAnalyzer : DiagnosticAnalyzer
 			_ => null,
 		};
 		var targetType = target is null ? null : context.SemanticModel.GetTypeInfo(target).Type.OriginalDefinition;
-		if (targetType?.Equals(concurrentDictionary) is not true)
+		if (!SymbolEqualityComparer.Default.Equals(targetType, concurrentDictionary))
 			return;
 
 		context.ReportDiagnostic(Diagnostic.Create(s_rule, name.GetLocation()));

--- a/src/Faithlife.Analyzers/IfNotNullAnalyzer.cs
+++ b/src/Faithlife.Analyzers/IfNotNullAnalyzer.cs
@@ -40,7 +40,7 @@ public sealed class IfNotNullAnalyzer : DiagnosticAnalyzer
 		var methodSymbol = context.SemanticModel.GetSymbolInfo(syntax.Expression).Symbol as IMethodSymbol;
 		if (methodSymbol == null ||
 			(methodSymbol.ReducedFrom == null && methodSymbol.ConstructedFrom == null) ||
-			!ifNotNullMethods.Any(x => x.Equals(methodSymbol.ReducedFrom) || x.Equals(methodSymbol.ConstructedFrom)))
+			!ifNotNullMethods.Any(x => SymbolEqualityComparer.Default.Equals(x, methodSymbol.ReducedFrom) || SymbolEqualityComparer.Default.Equals(x, methodSymbol.ConstructedFrom)))
 			return;
 
 		context.ReportDiagnostic(Diagnostic.Create(s_rule, syntax.GetLocation()));

--- a/src/Faithlife.Analyzers/IfNotNullCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/IfNotNullCodeFixProvider.cs
@@ -63,7 +63,7 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 
 		// Handle default value generators.
 		if (methodSymbol.Parameters.Length > defaultArgumentIndex &&
-			(methodSymbol.Arity == 1 || !Equals(methodSymbol.Parameters[defaultArgumentIndex].Type, outputTypeArgument)))
+			(methodSymbol.Arity == 1 || !SymbolEqualityComparer.Default.Equals(methodSymbol.Parameters[defaultArgumentIndex].Type, outputTypeArgument)))
 		{
 			if (defaultValueExpression is LambdaExpressionSyntax lambda)
 			{
@@ -116,7 +116,7 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 			// evaluates to the correct type.
 			if (outputTypeIsNullable &&
 				(defaultValueExpression is DefaultExpressionSyntax ||
-					 (defaultValueExpression is LiteralExpressionSyntax defaultLiteral && defaultLiteral.IsKind(SyntaxKind.NullLiteralExpression))))
+					(defaultValueExpression is LiteralExpressionSyntax defaultLiteral && defaultLiteral.IsKind(SyntaxKind.NullLiteralExpression))))
 			{
 				defaultValueExpression = null;
 			}

--- a/src/Faithlife.Analyzers/OverloadWithStringComparerAnalyzer.cs
+++ b/src/Faithlife.Analyzers/OverloadWithStringComparerAnalyzer.cs
@@ -25,7 +25,7 @@ public sealed class OverloadWithStringComparerAnalyzer : DiagnosticAnalyzer
 					var targetMethod = operation.TargetMethod;
 
 					if (targetMethod != null &&
-						Equals(targetMethod.ContainingType, enumerableType) &&
+						SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, enumerableType) &&
 						(targetMethod.Name == "OrderBy" || targetMethod.Name == "OrderByDescending" || targetMethod.Name == "ThenBy" || targetMethod.Name == "ThenByDescending") &&
 						targetMethod.TypeArguments.Length == 2 &&
 						targetMethod.TypeArguments[1].SpecialType == SpecialType.System_String &&

--- a/src/Faithlife.Analyzers/OverloadWithStringComparisonAnalyzer.cs
+++ b/src/Faithlife.Analyzers/OverloadWithStringComparisonAnalyzer.cs
@@ -42,7 +42,7 @@ public sealed class OverloadWithStringComparisonAnalyzer : DiagnosticAnalyzer
 							if (lastArgument.Value.Kind == OperationKind.FieldReference)
 							{
 								var fieldSymbol = ((IFieldReferenceOperation) lastArgument.Value).Field;
-								if (Equals(fieldSymbol?.ContainingType, stringComparisonType) && fieldSymbol.Name == "Ordinal")
+								if (SymbolEqualityComparer.Default.Equals(fieldSymbol?.ContainingType, stringComparisonType) && fieldSymbol.Name == "Ordinal")
 								{
 									// right overload, wrong value
 									operationContext.ReportDiagnostic(Diagnostic.Create(s_avoidStringEqualsRule, operation.GetMethodNameLocation()));
@@ -68,9 +68,9 @@ public sealed class OverloadWithStringComparisonAnalyzer : DiagnosticAnalyzer
 				return true;
 			if (parameter.Type.SpecialType == SpecialType.System_Char)
 				return true;
-			if (parameter.Type.Equals(stringComparisonType))
+			if (SymbolEqualityComparer.Default.Equals(parameter.Type, stringComparisonType))
 				return true;
-			if (parameter.Type.Equals(cultureInfoType))
+			if (SymbolEqualityComparer.Default.Equals(parameter.Type, cultureInfoType))
 				return true;
 		}
 

--- a/src/Faithlife.Analyzers/ToReadOnlyCollectionAnalyzer.cs
+++ b/src/Faithlife.Analyzers/ToReadOnlyCollectionAnalyzer.cs
@@ -36,7 +36,7 @@ public sealed class ToReadOnlyCollectionAnalyzer : DiagnosticAnalyzer
 	{
 		var invocationOperation = (IInvocationOperation) context.Operation;
 		var targetMethod = invocationOperation.TargetMethod;
-		if (Equals(targetMethod.ContainingType, enumerableUtility) && targetMethod.Name == "ToReadOnlyCollection")
+		if (SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType, enumerableUtility) && targetMethod.Name == "ToReadOnlyCollection")
 		{
 			var expressionStatement = invocationOperation.Syntax.FirstAncestorOrSelf<ExpressionStatementSyntax>();
 			if (expressionStatement?.Expression is AssignmentExpressionSyntax assignmentExpression)

--- a/src/Faithlife.Analyzers/UntilCanceledAnalyzer.cs
+++ b/src/Faithlife.Analyzers/UntilCanceledAnalyzer.cs
@@ -51,7 +51,7 @@ public sealed class UntilCanceledAnalyzer : DiagnosticAnalyzer
 				return;
 
 			var method = context.SemanticModel.GetSymbolInfo(invocation.Expression).Symbol as IMethodSymbol;
-			if (!Equals(method?.ContainingType, asyncEnumerableUtility))
+			if (!SymbolEqualityComparer.Default.Equals(method?.ContainingType, asyncEnumerableUtility))
 				return;
 
 			if (invocation.ArgumentList.Arguments.Count != 0)
@@ -63,7 +63,7 @@ public sealed class UntilCanceledAnalyzer : DiagnosticAnalyzer
 
 			var ienumerable = context.SemanticModel.Compilation.GetTypeByMetadataName("System.Collections.Generic.IEnumerable`1");
 			var returnTypeSymbol = ModelExtensions.GetSymbolInfo(context.SemanticModel, containingMethod.ReturnType).Symbol as INamedTypeSymbol;
-			if (Equals(returnTypeSymbol?.ConstructedFrom, ienumerable) && Equals(returnTypeSymbol?.TypeArguments[0], asyncAction))
+			if (SymbolEqualityComparer.Default.Equals(returnTypeSymbol?.ConstructedFrom, ienumerable) && SymbolEqualityComparer.Default.Equals(returnTypeSymbol?.TypeArguments[0], asyncAction))
 				return;
 
 			context.ReportDiagnostic(Diagnostic.Create(s_rule, invocation.ArgumentList.GetLocation()));

--- a/src/Faithlife.Analyzers/UntilCanceledCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/UntilCanceledCodeFixProvider.cs
@@ -48,14 +48,14 @@ public sealed class UntilCanceledCodeFixProvider : CodeFixProvider
 			if (symbolInfo.Symbol is null)
 				return false;
 
-			if (symbolInfo.Symbol.Equals(iworkState))
+			if (SymbolEqualityComparer.Default.Equals(symbolInfo.Symbol, iworkState))
 				return true;
 
 			var namedTypeSymbol = symbolInfo.Symbol as INamedTypeSymbol;
 			if (namedTypeSymbol is null)
 				return false;
 
-			return namedTypeSymbol.AllInterfaces.Any(x => x.Equals(iworkState));
+			return namedTypeSymbol.AllInterfaces.Any(x => SymbolEqualityComparer.Default.Equals(x, iworkState));
 		});
 
 		foreach (var parameter in workStateParameters)

--- a/src/Faithlife.Analyzers/UriToStringAnalyzer.cs
+++ b/src/Faithlife.Analyzers/UriToStringAnalyzer.cs
@@ -27,7 +27,7 @@ public sealed class UriToStringAnalyzer : DiagnosticAnalyzer
 	private static void AnalyzeOperation(OperationAnalysisContext context, ISymbol uriToStringMethod)
 	{
 		var invocation = (IInvocationOperation) context.Operation;
-		if (!uriToStringMethod.Equals(invocation.TargetMethod))
+		if (!SymbolEqualityComparer.Default.Equals(uriToStringMethod, invocation.TargetMethod))
 			return;
 
 		context.ReportDiagnostic(Diagnostic.Create(s_rule, invocation.Syntax.GetLocation()));

--- a/tests/Faithlife.Analyzers.Tests/Faithlife.Analyzers.Tests.csproj
+++ b/tests/Faithlife.Analyzers.Tests/Faithlife.Analyzers.Tests.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.2.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/tests/Faithlife.Analyzers.Tests/SelfAnalysisTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/SelfAnalysisTests.cs
@@ -36,9 +36,9 @@ public class SelfAnalysisTests
 			solution = solution.AddDocument(documentId, fileName, SourceText.From(File.OpenRead(source)), filePath: source);
 		}
 
-		var project = solution.GetProject(projectId);
+		var project = solution.GetProject(projectId)!;
 		var compilation = await project.GetCompilationAsync().ConfigureAwait(false);
-		var compilationWithAnalyzers = compilation.WithAnalyzers(ImmutableArray.CreateRange(typeof(CurrentAsyncWorkItemAnalyzer)
+		var compilationWithAnalyzers = compilation!.WithAnalyzers(ImmutableArray.CreateRange(typeof(CurrentAsyncWorkItemAnalyzer)
 			.Assembly
 			.GetTypes()
 			.Where(x => x.BaseType == typeof(DiagnosticAnalyzer))

--- a/tests/Faithlife.Analyzers.Tests/Verifiers/CodeFixVerifier.cs
+++ b/tests/Faithlife.Analyzers.Tests/Verifiers/CodeFixVerifier.cs
@@ -100,13 +100,13 @@ public abstract partial class CodeFixVerifier : DiagnosticVerifier
 			if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
 			{
 				// Format and get the compiler diagnostics again so that the locations make sense in the output
-				document = document.WithSyntaxRoot(Formatter.Format(document.GetSyntaxRootAsync().GetAwaiter().GetResult(), Formatter.Annotation, document.Project.Solution.Workspace));
+				document = document.WithSyntaxRoot(Formatter.Format(document.GetSyntaxRootAsync().GetAwaiter().GetResult()!, Formatter.Annotation, document.Project.Solution.Workspace));
 				newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, GetCompilerDiagnostics(document));
 
 				Assert.IsTrue(false,
 					string.Format(CultureInfo.InvariantCulture, "Fix introduced new compiler diagnostics:\r\n{0}\r\n\r\nNew document:\r\n{1}\r\n",
 						string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString())),
-						document.GetSyntaxRootAsync().GetAwaiter().GetResult().ToFullString()));
+						document.GetSyntaxRootAsync().GetAwaiter().GetResult()!.ToFullString()));
 			}
 
 			// check if there are analyzer diagnostics left after the code fix


### PR DESCRIPTION
A number of nullability warnings are ignored and should be addressed, but can be done so separately.

IfNotNullCodeFixProvider tests fail on versions newer than 3.5.0.