### PR TITLE
Add regression test for StringBuilder AppendLine

### DIFF
--- a/src/Faithlife.Analyzers/Faithlife.Analyzers.csproj
+++ b/src/Faithlife.Analyzers/Faithlife.Analyzers.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Faithlife.Analyzers/Faithlife.Analyzers.csproj
+++ b/src/Faithlife.Analyzers/Faithlife.Analyzers.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 

--- a/tests/Faithlife.Analyzers.Tests/Faithlife.Analyzers.Tests.csproj
+++ b/tests/Faithlife.Analyzers.Tests/Faithlife.Analyzers.Tests.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/tests/Faithlife.Analyzers.Tests/Faithlife.Analyzers.Tests.csproj
+++ b/tests/Faithlife.Analyzers.Tests/Faithlife.Analyzers.Tests.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/tests/Faithlife.Analyzers.Tests/InterpolatedStringTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/InterpolatedStringTests.cs
@@ -51,7 +51,8 @@ public class TestClass
 {
 	public TestClass()
 	{
-		new System.Text.StringBuilder().AppendLine(System.Globalization.CultureInfo.CurrentCulture, $""{""environment""}"");
+		string one = ""one"";
+		new System.Text.StringBuilder().AppendLine(System.Globalization.CultureInfo.CurrentCulture, $""{one} costs $0.00"");
 	}
 }
 ";

--- a/tests/Faithlife.Analyzers.Tests/InterpolatedStringTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/InterpolatedStringTests.cs
@@ -44,6 +44,21 @@ namespace TestApplication
 	}
 
 	[Test]
+	public void ValidAppendLine()
+	{
+		const string validProgram = @"
+public class TestClass
+{
+	public TestClass()
+	{
+		new System.Text.StringBuilder().AppendLine(System.Globalization.CultureInfo.CurrentCulture, $""{""environment""}"");
+	}
+}
+";
+		VerifyCSharpDiagnostic(validProgram);
+	}
+
+	[Test]
 	public void InvalidInterpolatedString()
 	{
 		const string invalidProgram = @"


### PR DESCRIPTION
This test fails the [GreaterOrEqual](https://github.com/Faithlife/FaithlifeAnalyzers/blob/6a56cb914b3e4a1fb0f45b7e767e941bc8feee52/tests/Faithlife.Analyzers.Tests/Helpers/DiagnosticVerifier.Helper.cs#L64) assertion in `GetSortedDiagnosticsFromDocuments` with:

```
 ValidAppendLine Failed:   Argument 2 must be passed with the 'ref' keyword
Argument 2 must be passed with the 'ref' keyword
Expected: greater than or equal to 4
But was:  0

 at Faithlife.Analyzers.Tests.DiagnosticVerifier.GetSortedDiagnosticsFromDocuments(DiagnosticAnalyzer analyzer, Document[] documents) in C:\Code\FaithlifeAnalyzers\tests\Faithlife.Analyzers.Tests\Helpers\DiagnosticVerifier.Helper.cs:line 64
 at Faithlife.Analyzers.Tests.DiagnosticVerifier.GetSortedDiagnostics(String[] sources, String language, DiagnosticAnalyzer analyzer) in C:\Code\FaithlifeAnalyzers\tests\Faithlife.Analyzers.Tests\Helpers\DiagnosticVerifier.Helper.cs:line 39
 at Faithlife.Analyzers.Tests.DiagnosticVerifier.VerifyDiagnostics(String[] sources, String language, DiagnosticAnalyzer analyzer, DiagnosticResult[] expected) in C:\Code\FaithlifeAnalyzers\tests\Faithlife.Analyzers.Tests\Verifiers\DiagnosticVerifier.cs:line 87
 at Faithlife.Analyzers.Tests.DiagnosticVerifier.VerifyCSharpDiagnostic(String source, DiagnosticResult[] expected) in C:\Code\FaithlifeAnalyzers\tests\Faithlife.Analyzers.Tests\Verifiers\DiagnosticVerifier.cs:line 41
 at Faithlife.Analyzers.Tests.InterpolatedStringTests.ValidAppendLine() in C:\Code\FaithlifeAnalyzers\tests\Faithlife.Analyzers.Tests\InterpolatedStringTests.cs:line 58
```