### PR TITLE
Replace FormatInvariant with interpolated string

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -10,6 +10,7 @@ New analyzers are considered "minor" changes (even though adding a new analyzer 
 or errors for existing code when the package is upgraded).
 
 * Add FL0017: Do not switch on a constant value.
+* Add FL0018: FormatInvariant deprecation.
 
 ## 1.3.1
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -9,6 +9,8 @@ Prefix the description of the change with `[major]`, `[minor]`, or `[patch]` in 
 New analyzers are considered "minor" changes (even though adding a new analyzer is likely to generate warnings
 or errors for existing code when the package is upgraded).
 
+* Add FL0017: Do not switch on a constant value.
+
 ## 1.3.1
 
 * Fix false positive diagnostic for FL0008.

--- a/src/Faithlife.Analyzers/FormatInvariantAnalyzer.cs
+++ b/src/Faithlife.Analyzers/FormatInvariantAnalyzer.cs
@@ -1,0 +1,56 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Faithlife.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class FormatInvariantAnalyzer : DiagnosticAnalyzer
+{
+	public override void Initialize(AnalysisContext context)
+	{
+		context.EnableConcurrentExecution();
+		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+		context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
+		{
+			var stringUtilityType = compilationStartAnalysisContext.Compilation.GetTypeByMetadataName("Libronix.Utility.StringUtility");
+			if (stringUtilityType == null)
+				return;
+
+			var formatInvariantMethods = stringUtilityType.GetMembers("FormatInvariant");
+			if (formatInvariantMethods.Length == 0)
+				return;
+
+			compilationStartAnalysisContext.RegisterSyntaxNodeAction(c => AnalyzeSyntax(c, formatInvariantMethods), SyntaxKind.InvocationExpression);
+		});
+	}
+
+	public const string DiagnosticId = "FL0018";
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
+
+	private static void AnalyzeSyntax(SyntaxNodeAnalysisContext context, ImmutableArray<ISymbol> formatInvariantMethods)
+	{
+		var syntax = (InvocationExpressionSyntax) context.Node;
+
+		var methodSymbol = context.SemanticModel.GetSymbolInfo(syntax.Expression).Symbol as IMethodSymbol;
+		if (methodSymbol == null ||
+			(methodSymbol.ReducedFrom == null && methodSymbol.ConstructedFrom == null) ||
+			!formatInvariantMethods.Any(x => SymbolEqualityComparer.Default.Equals(x, methodSymbol.ReducedFrom) || SymbolEqualityComparer.Default.Equals(x, methodSymbol.ConstructedFrom)))
+			return;
+
+		context.ReportDiagnostic(Diagnostic.Create(s_rule, syntax.GetLocation()));
+	}
+
+	private static readonly DiagnosticDescriptor s_rule = new DiagnosticDescriptor(
+		id: DiagnosticId,
+		title: "FormatInvariant deprecation",
+		messageFormat: "Prefer string interpolation over FormatInvariant",
+		category: "Usage",
+		defaultSeverity: DiagnosticSeverity.Info,
+		isEnabledByDefault: true,
+		helpLinkUri: $"https://github.com/Faithlife/FaithlifeAnalyzers/wiki/{DiagnosticId}");
+}

--- a/src/Faithlife.Analyzers/FormatInvariantAnalyzer.cs
+++ b/src/Faithlife.Analyzers/FormatInvariantAnalyzer.cs
@@ -42,6 +42,13 @@ public sealed class FormatInvariantAnalyzer : DiagnosticAnalyzer
 			!formatInvariantMethods.Any(x => SymbolEqualityComparer.Default.Equals(x, methodSymbol.ReducedFrom) || SymbolEqualityComparer.Default.Equals(x, methodSymbol.ConstructedFrom)))
 			return;
 
+		var memberAccessExpression = syntax.Expression as MemberAccessExpressionSyntax;
+		if (memberAccessExpression is null)
+			return;
+
+		if (!memberAccessExpression.Expression.IsKind(SyntaxKind.StringLiteralExpression))
+			return;
+
 		context.ReportDiagnostic(Diagnostic.Create(s_rule, syntax.GetLocation()));
 	}
 

--- a/src/Faithlife.Analyzers/FormatInvariantCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/FormatInvariantCodeFixProvider.cs
@@ -40,7 +40,7 @@ public sealed class FormatInvariantCodeFixProvider : CodeFixProvider
 			return;
 
 		var interpolatedStringExpression = InterpolatedStringExpression(Token(SyntaxKind.InterpolatedStringStartToken));
-		var matches = Regex.Matches(formatString, @"(?!\\){\s*(\d+)(:[^}]+)?\s*}");
+		var matches = Regex.Matches(formatString, @"(?!\\){\s*(\d+)(,-?\d+)?(:[^}]+)?\s*}");
 		if (matches.Count == 0)
 			return;
 
@@ -66,7 +66,9 @@ public sealed class FormatInvariantCodeFixProvider : CodeFixProvider
 
 			var interpolation = Interpolation(SyntaxUtility.SimplifiableParentheses(arg.Expression));
 			if (match.Groups[2].Success)
-				interpolation = interpolation.WithFormatClause(InterpolationFormatClause(Token(SyntaxKind.ColonToken), InterpolatedStringTextToken(match.Groups[2].Value.Substring(1))));
+				interpolation = interpolation.WithAlignmentClause(InterpolationAlignmentClause(Token(SyntaxKind.CommaToken), ParseExpression(match.Groups[2].Value.Substring(1))));
+			if (match.Groups[3].Success)
+				interpolation = interpolation.WithFormatClause(InterpolationFormatClause(Token(SyntaxKind.ColonToken), InterpolatedStringTextToken(match.Groups[3].Value.Substring(1))));
 			interpolatedStringExpression = interpolatedStringExpression.AddContents(interpolation);
 
 			index = match.Index + match.Length;

--- a/src/Faithlife.Analyzers/FormatInvariantCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/FormatInvariantCodeFixProvider.cs
@@ -1,0 +1,110 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Simplification;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Faithlife.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(FormatInvariantCodeFixProvider)), Shared]
+public sealed class FormatInvariantCodeFixProvider : CodeFixProvider
+{
+	public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(FormatInvariantAnalyzer.DiagnosticId);
+
+	public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+	public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+	{
+		var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+		var diagnostic = context.Diagnostics.First();
+		var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+		var diagnosticNode = root.FindNode(diagnosticSpan);
+
+		var invocation = diagnosticNode.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+		if (invocation is null)
+			return;
+
+		if (invocation.Expression is not MemberAccessExpressionSyntax { Expression: LiteralExpressionSyntax invocationTarget } || !invocationTarget.IsKind(SyntaxKind.StringLiteralExpression))
+			return;
+
+		var formatString = invocationTarget.Token.Value as string;
+		if (formatString is null)
+			return;
+
+		var replacementExpression = InterpolatedStringExpression(Token(SyntaxKind.InterpolatedStringStartToken));
+		var matches = Regex.Matches(formatString, @"(?!\\){\s*(\d+)(:[^}]+)?\s*}");
+		if (matches.Count == 0)
+			return;
+
+		var index = 0;
+		foreach (Match match in matches)
+		{
+			if (index < match.Index)
+				replacementExpression = replacementExpression.AddContents(InterpolatedStringText(formatString.Substring(index, match.Index - index)));
+
+			if (!int.TryParse(match.Groups[1].Value, out var argIndex) || argIndex < 0 || argIndex > invocation.ArgumentList.Arguments.Count )
+				return;
+
+			var arg = invocation.ArgumentList.Arguments[argIndex];
+			var interpolation = Interpolation(SyntaxUtility.SimplifiableParentheses(arg.Expression));
+			if (match.Groups[2].Success)
+				interpolation = interpolation.WithFormatClause(InterpolationFormatClause(Token(SyntaxKind.ColonToken), InterpolatedStringTextToken(match.Groups[2].Value.Substring(1))));
+			replacementExpression = replacementExpression.AddContents(interpolation);
+
+			index = match.Index + match.Length;
+		}
+
+		if (index < formatString.Length)
+			replacementExpression = replacementExpression.AddContents(InterpolatedStringText(formatString.Substring(index)));
+
+		context.RegisterCodeFix(
+			CodeAction.Create(
+				title: "Use interpolated string",
+				createChangedDocument: token => ReplaceValueAsync(
+					context.Document,
+					invocation,
+					SyntaxUtility.SimplifiableParentheses(replacementExpression),
+					token),
+				c_fixName),
+			diagnostic);
+	}
+
+	private static InterpolatedStringTextSyntax InterpolatedStringText(string text) =>
+		SyntaxFactory.InterpolatedStringText().WithTextToken(InterpolatedStringTextToken(text));
+
+	private static SyntaxToken InterpolatedStringTextToken(string text) =>
+		Token(
+			TriviaList(),
+			SyntaxKind.InterpolatedStringTextToken,
+			text,
+			text,
+			TriviaList());
+
+	private static async Task<Document> ReplaceValueAsync(Document document, SyntaxNode replacementTarget, SyntaxNode replacementNode, CancellationToken cancellationToken)
+	{
+		var root = (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false))
+			.ReplaceNode(replacementTarget, replacementNode);
+
+		var usingDirective = root.DescendantNodes()
+			.OfType<UsingDirectiveSyntax>()
+			.FirstOrDefault(x => AreEquivalent(x.Name, s_libronixUtilityNamespace));
+
+		if (usingDirective != null)
+			root = root.ReplaceNode(usingDirective, usingDirective.WithAdditionalAnnotations(Simplifier.Annotation));
+
+		return await Simplifier.ReduceAsync(
+			await Simplifier.ReduceAsync(document.WithSyntaxRoot(root), cancellationToken: cancellationToken).ConfigureAwait(false),
+			cancellationToken: cancellationToken).ConfigureAwait(false);
+	}
+
+	private static readonly NameSyntax s_libronixUtilityNamespace = ParseName("Libronix.Utility");
+
+	private const string c_fixName = "use-modern-language-features";
+}

--- a/src/Faithlife.Analyzers/FormatInvariantCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/FormatInvariantCodeFixProvider.cs
@@ -65,10 +65,10 @@ public sealed class FormatInvariantCodeFixProvider : CodeFixProvider
 			}
 
 			var interpolation = Interpolation(SyntaxUtility.SimplifiableParentheses(arg.Expression));
-			if (match.Groups[2].Success)
-				interpolation = interpolation.WithAlignmentClause(InterpolationAlignmentClause(Token(SyntaxKind.CommaToken), ParseExpression(match.Groups[2].Value.Substring(1))));
-			if (match.Groups[3].Success)
-				interpolation = interpolation.WithFormatClause(InterpolationFormatClause(Token(SyntaxKind.ColonToken), InterpolatedStringTextToken(match.Groups[3].Value.Substring(1))));
+			if (match.Groups[2] is { Success: true, Value: { } alignment })
+				interpolation = interpolation.WithAlignmentClause(InterpolationAlignmentClause(Token(SyntaxKind.CommaToken), ParseExpression(alignment.Substring(1))));
+			if (match.Groups[3] is { Success: true, Value: { } format })
+				interpolation = interpolation.WithFormatClause(InterpolationFormatClause(Token(SyntaxKind.ColonToken), InterpolatedStringTextToken(format.Substring(1))));
 			interpolatedStringExpression = interpolatedStringExpression.AddContents(interpolation);
 
 			index = match.Index + match.Length;

--- a/src/Faithlife.Analyzers/FormatInvariantCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/FormatInvariantCodeFixProvider.cs
@@ -60,7 +60,7 @@ public sealed class FormatInvariantCodeFixProvider : CodeFixProvider
 			if (!requiresInvariant)
 			{
 				var typeInfo = semanticModel.GetTypeInfo(arg.Expression);
-				if (!SymbolEqualityComparer.Default.Equals(typeInfo.Type, stringType))
+				if (typeInfo.Type.TypeKind is not TypeKind.Enum && !SymbolEqualityComparer.Default.Equals(typeInfo.Type, stringType))
 					requiresInvariant = true;
 			}
 

--- a/src/Faithlife.Analyzers/FormatInvariantCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/FormatInvariantCodeFixProvider.cs
@@ -103,13 +103,20 @@ public sealed class FormatInvariantCodeFixProvider : CodeFixProvider
 	private static InterpolatedStringTextSyntax InterpolatedStringText(string text) =>
 		SyntaxFactory.InterpolatedStringText().WithTextToken(InterpolatedStringTextToken(text));
 
-	private static SyntaxToken InterpolatedStringTextToken(string text) =>
-		Token(
+	private static SyntaxToken InterpolatedStringTextToken(string text)
+	{
+		var escapedText = text
+			.Replace("\\", "\\\\")
+			.Replace("\r", "\\r")
+			.Replace("\n", "\\n")
+			.Replace("\"", "\\\"");
+		return Token(
 			TriviaList(),
 			SyntaxKind.InterpolatedStringTextToken,
-			text,
-			text,
+			escapedText,
+			escapedText,
 			TriviaList());
+	}
 
 	private static async Task<Document> ReplaceValueAsync(Document document, SyntaxNode replacementTarget, SyntaxNode replacementNode, CancellationToken cancellationToken)
 	{

--- a/tests/Faithlife.Analyzers.Tests/FormatInvariantTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/FormatInvariantTests.cs
@@ -30,35 +30,36 @@ namespace TestApplication
 		VerifyCSharpDiagnostic(validProgram);
 	}
 
-	[Test]
-	public void InvalidFormat()
+	[TestCase(@"""pre {0} post"".FormatInvariant(foo)", @"$""pre {foo} post""")]
+	[TestCase(@"""pre {0} mid {1} dup {0} format {1:D1} parens {2} alignment {1,-10} alignment+format {1,10:D1} post"".FormatInvariant(foo, 10, b ? 1 : 2)", @"FormattableString.Invariant($""pre {foo} mid {10} dup {foo} format {10:D1} parens {(b ? 1 : 2)} alignment {10,-10} alignment+format {10,10:D1} post"")")]
+	public void InvalidFormat(string invalidCode, string fixedCode)
 	{
-		const string invalidProgram = @"using System;
+		var invalidProgram = $@"using System;
 using Libronix.Utility;
 
 namespace Libronix.Utility
-{
+{{
 	public static class StringUtility
-	{
+	{{
 		public static string FormatInvariant(this string format, params object[] args) => throw new NotImplementedException();
-	}
-}
+	}}
+}}
 
 namespace TestApplication
-{
+{{
 	public class TestClass
-	{
-		public TestClass()
-		{
+	{{
+		public TestClass(bool b)
+		{{
 			var foo = ""foo"";
-			Method(""pre {0} post"".FormatInvariant(foo));
-		}
+			Method({invalidCode});
+		}}
 
 		private void Method(string parameter)
-		{
-		}
-	}
-}";
+		{{
+		}}
+	}}
+}}";
 		var expected = new DiagnosticResult
 		{
 			Id = FormatInvariantAnalyzer.DiagnosticId,
@@ -69,99 +70,31 @@ namespace TestApplication
 
 		VerifyCSharpDiagnostic(invalidProgram, expected);
 
-		const string fixedProgram = @"using System;
+		var fixedProgram = $@"using System;
 
 namespace Libronix.Utility
-{
+{{
 	public static class StringUtility
-	{
+	{{
 		public static string FormatInvariant(this string format, params object[] args) => throw new NotImplementedException();
-	}
-}
+	}}
+}}
 
 namespace TestApplication
-{
+{{
 	public class TestClass
-	{
-		public TestClass()
-		{
-			var foo = ""foo"";
-			Method($""pre {foo} post"");
-		}
-
-		private void Method(string parameter)
-		{
-		}
-	}
-}";
-
-		VerifyCSharpFix(invalidProgram, fixedProgram, 0);
-	}
-
-	[Test]
-	public void InvalidFormatComplex()
-	{
-		const string invalidProgram = @"using System;
-using Libronix.Utility;
-
-namespace Libronix.Utility
-{
-	public static class StringUtility
-	{
-		public static string FormatInvariant(this string format, params object[] args) => throw new NotImplementedException();
-	}
-}
-
-namespace TestApplication
-{
-	public class TestClass
-	{
+	{{
 		public TestClass(bool b)
-		{
+		{{
 			var foo = ""foo"";
-			Method(""pre {0} mid {1} dup {0} format {1:D1} parens {2} alignment {1,-10} alignment+format {1,10:D1} post"".FormatInvariant(foo, 10, b ? 1 : 2));
-		}
+			Method({fixedCode});
+		}}
 
 		private void Method(string parameter)
-		{
-		}
-	}
-}";
-		var expected = new DiagnosticResult
-		{
-			Id = FormatInvariantAnalyzer.DiagnosticId,
-			Message = "Prefer string interpolation over FormatInvariant",
-			Severity = DiagnosticSeverity.Info,
-			Locations = new[] { new DiagnosticResultLocation("Test0.cs", 19, 11) },
-		};
-
-		VerifyCSharpDiagnostic(invalidProgram, expected);
-
-		const string fixedProgram = @"using System;
-
-namespace Libronix.Utility
-{
-	public static class StringUtility
-	{
-		public static string FormatInvariant(this string format, params object[] args) => throw new NotImplementedException();
-	}
-}
-
-namespace TestApplication
-{
-	public class TestClass
-	{
-		public TestClass(bool b)
-		{
-			var foo = ""foo"";
-			Method(FormattableString.Invariant($""pre {foo} mid {10} dup {foo} format {10:D1} parens {(b ? 1 : 2)} alignment {10,-10} alignment+format {10,10:D1} post""));
-		}
-
-		private void Method(string parameter)
-		{
-		}
-	}
-}";
+		{{
+		}}
+	}}
+}}";
 
 		VerifyCSharpFix(invalidProgram, fixedProgram, 0);
 	}

--- a/tests/Faithlife.Analyzers.Tests/FormatInvariantTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/FormatInvariantTests.cs
@@ -154,7 +154,7 @@ namespace TestApplication
 		public TestClass(bool b)
 		{
 			var foo = ""foo"";
-			Method($""pre {foo} mid {10} dup {foo} format {10:D1} parens {(b ? 1 : 2)} post"");
+			Method(FormattableString.Invariant($""pre {foo} mid {10} dup {foo} format {10:D1} parens {(b ? 1 : 2)} post""));
 		}
 
 		private void Method(string parameter)

--- a/tests/Faithlife.Analyzers.Tests/FormatInvariantTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/FormatInvariantTests.cs
@@ -1,0 +1,73 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Framework;
+
+namespace Faithlife.Analyzers.Tests;
+
+[TestFixture]
+public sealed class FormatInvariantTests : CodeFixVerifier
+{
+	[Test]
+	public void ValidFormat()
+	{
+		const string validProgram = @"
+namespace TestApplication
+{
+	public class TestClass
+	{
+		public TestClass()
+		{
+			var foo = ""foo"";
+			Method($""{foo}"");
+		}
+
+		private void Method(string parameter)
+		{
+		}
+	}
+}";
+		VerifyCSharpDiagnostic(validProgram);
+	}
+
+	[Test]
+	public void InvalidFormat()
+	{
+		const string invalidProgram = @"using System;
+using Libronix.Utility;
+
+namespace Libronix.Utility
+{
+	public static class StringUtility
+	{
+		public static string FormatInvariant(this string format, params object[] args) => throw new NotImplementedException();
+	}
+}
+
+namespace TestApplication
+{
+	public class TestClass
+	{
+		public TestClass()
+		{
+			var foo = ""foo"";
+			Method(""{0}"".FormatInvariant(foo));
+		}
+
+		private void Method(string parameter)
+		{
+		}
+	}
+}";
+		var expected = new DiagnosticResult
+		{
+			Id = FormatInvariantAnalyzer.DiagnosticId,
+			Message = "Prefer string interpolation over FormatInvariant",
+			Severity = DiagnosticSeverity.Info,
+			Locations = new[] { new DiagnosticResultLocation("Test0.cs", 19, 11) },
+		};
+
+		VerifyCSharpDiagnostic(invalidProgram, expected);
+	}
+
+	protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new FormatInvariantAnalyzer();
+}

--- a/tests/Faithlife.Analyzers.Tests/FormatInvariantTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/FormatInvariantTests.cs
@@ -119,7 +119,7 @@ namespace TestApplication
 		public TestClass(bool b)
 		{
 			var foo = ""foo"";
-			Method(""pre {0} mid {1} dup {0} format {1:D1} parens {2} post"".FormatInvariant(foo, 10, b ? 1 : 2));
+			Method(""pre {0} mid {1} dup {0} format {1:D1} parens {2} alignment {1,-10} alignment+format {1,10:D1} post"".FormatInvariant(foo, 10, b ? 1 : 2));
 		}
 
 		private void Method(string parameter)
@@ -154,7 +154,7 @@ namespace TestApplication
 		public TestClass(bool b)
 		{
 			var foo = ""foo"";
-			Method(FormattableString.Invariant($""pre {foo} mid {10} dup {foo} format {10:D1} parens {(b ? 1 : 2)} post""));
+			Method(FormattableString.Invariant($""pre {foo} mid {10} dup {foo} format {10:D1} parens {(b ? 1 : 2)} alignment {10,-10} alignment+format {10,10:D1} post""));
 		}
 
 		private void Method(string parameter)

--- a/tests/Faithlife.Analyzers.Tests/FormatInvariantTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/FormatInvariantTests.cs
@@ -32,6 +32,8 @@ namespace TestApplication
 
 	[TestCase(@"""pre {0} post"".FormatInvariant(foo)", @"$""pre {foo} post""")]
 	[TestCase(@"""pre {0} mid {1} dup {0} format {1:D1} parens {2} alignment {1,-10} alignment+format {1,10:D1} post"".FormatInvariant(foo, 10, b ? 1 : 2)", @"FormattableString.Invariant($""pre {foo} mid {10} dup {foo} format {10:D1} parens {(b ? 1 : 2)} alignment {10,-10} alignment+format {10,10:D1} post"")")]
+	[TestCase(@"""with quotes \""{0}\"" post"".FormatInvariant(foo)", @"$""with quotes \""{foo}\"" post""")]
+	[TestCase(@"""with newline \n{0} post"".FormatInvariant(foo)", @"$""with newline \n{foo} post""")]
 	public void InvalidFormat(string invalidCode, string fixedCode)
 	{
 		var invalidProgram = $@"using System;

--- a/tests/Faithlife.Analyzers.Tests/FormatInvariantTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/FormatInvariantTests.cs
@@ -51,6 +51,7 @@ namespace TestApplication
 	[TestCase(@"""pre {0} mid {1} dup {0} format {1:D1} parens {2} alignment {1,-10} alignment+format {1,10:D1} post"".FormatInvariant(foo, 10, b ? 1 : 2)", @"FormattableString.Invariant($""pre {foo} mid {10} dup {foo} format {10:D1} parens {(b ? 1 : 2)} alignment {10,-10} alignment+format {10,10:D1} post"")")]
 	[TestCase(@"""with quotes \""{0}\"" post"".FormatInvariant(foo)", @"$""with quotes \""{foo}\"" post""")]
 	[TestCase(@"""with newline \n{0} post"".FormatInvariant(foo)", @"$""with newline \n{foo} post""")]
+	[TestCase(@"""with enum {0} {1} post"".FormatInvariant(DateTimeKind.Local, foo)", @"$""with enum {DateTimeKind.Local} {foo} post""")]
 	public void InvalidFormat(string invalidCode, string fixedCode)
 	{
 		var invalidProgram = $@"using System;

--- a/tests/Faithlife.Analyzers.Tests/FormatInvariantTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/FormatInvariantTests.cs
@@ -11,7 +11,17 @@ public sealed class FormatInvariantTests : CodeFixVerifier
 	[Test]
 	public void ValidFormat()
 	{
-		const string validProgram = @"
+		const string validProgram = @"using System;
+using Libronix.Utility;
+
+namespace Libronix.Utility
+{
+	public static class StringUtility
+	{
+		public static string FormatInvariant(this string format, params object[] args) => throw new NotImplementedException();
+	}
+}
+
 namespace TestApplication
 {
 	public class TestClass
@@ -20,6 +30,13 @@ namespace TestApplication
 		{
 			var foo = ""foo"";
 			Method($""{foo}"");
+
+			Method(StringUtility.FormatInvariant(""{0}"", foo));
+
+			var fmt = ""{0}"";
+			Method(fmt.FormatInvariant(1));
+
+			Method(StringUtility.FormatInvariant(fmt, foo));
 		}
 
 		private void Method(string parameter)


### PR DESCRIPTION
This analyzer produces an info diagnostic for `Libronix.Utility.StringUtility.FormatInvariant` use. `FormatInvariant` use can be replaced by interpolated strings in modern C#.

The code fix will replace:
```c#
"pre {0} mid {1} dup {0} format {1:D1} parens {2} alignment {1,-10} alignment+format {1,10:D1} post".FormatInvariant(foo, 10, b ? 1 : 2)
```
with
```c#
FormattableString.Invariant($"pre {foo} mid {10} dup {foo} format {10:D1} parens {(b ? 1 : 2)} alignment {10,-10} alignment+format {10,10:D1} post")
```

Open questions:
- Should repeated use of the same format argument be extracted to a variable if the expression is not a variable, constant, or literal?
- What about verbatim strings?
- What about non-extension-method invocation?
- Should the fix try to add `using static System.FormattableString`?
- Should enums require `Invariant`?