### PR TITLE
Update Roslyn packages to 4.14.0

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -1,0 +1,1 @@
+roslyn_correctness.assembly_reference_validation = relaxed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);1591;1998;NU5105;CA1014;CA1508</NoWarn>
+    <NoWarn>$(NoWarn);1591;1998;NU5105;CA1014;CA1508;CA1859</NoWarn>
     <DebugType>embedded</DebugType>
     <GitHubOrganization>Faithlife</GitHubOrganization>
     <RepositoryName>FaithlifeAnalyzers</RepositoryName>
@@ -30,8 +30,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
   </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Faithlife.Analyzers/DbConnectorCommandInterpolatedAnalyzer.cs
+++ b/src/Faithlife.Analyzers/DbConnectorCommandInterpolatedAnalyzer.cs
@@ -42,7 +42,7 @@ public sealed class DbConnectorCommandInterpolatedAnalyzer : DiagnosticAnalyzer
 	private static readonly DiagnosticDescriptor s_rule = new(
 		id: DiagnosticId,
 		title: "Use DbConnector.CommandFormat",
-		messageFormat: "Command should not be used with an interpolated string; use CommandFormat instead.",
+		messageFormat: "Command should not be used with an interpolated string; use CommandFormat instead",
 		category: "Usage",
 		defaultSeverity: DiagnosticSeverity.Warning,
 		isEnabledByDefault: true,

--- a/src/Faithlife.Analyzers/Faithlife.Analyzers.csproj
+++ b/src/Faithlife.Analyzers/Faithlife.Analyzers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -7,11 +7,12 @@
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NoWarn>$(NoWarn);NU5128;RS2008;CS8600;CS8602;CS8604;CS8619;CS8631</NoWarn>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Faithlife.Analyzers/GetOrAddValueAnalyzer.cs
+++ b/src/Faithlife.Analyzers/GetOrAddValueAnalyzer.cs
@@ -68,7 +68,7 @@ public sealed class GetOrAddValueAnalyzer : DiagnosticAnalyzer
 	private static readonly DiagnosticDescriptor s_rule = new(
 		id: DiagnosticId,
 		title: "GetOrAddValue() Usage",
-		messageFormat: "GetOrAddValue() is not threadsafe and should not be used with ConcurrentDictionary; use GetOrAdd() instead.",
+		messageFormat: "GetOrAddValue() is not threadsafe and should not be used with ConcurrentDictionary; use GetOrAdd() instead",
 		category: "Usage",
 		defaultSeverity: DiagnosticSeverity.Warning,
 		isEnabledByDefault: true,

--- a/src/Faithlife.Analyzers/IfNotNullCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/IfNotNullCodeFixProvider.cs
@@ -1,13 +1,11 @@
 using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
@@ -272,7 +270,7 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 							createChangedDocument: token => ReplaceValueAsync(
 								context.Document,
 								ifNotNullInvocation,
-								SyntaxUtility.SimplifiableParentheses(finalExpression),
+								finalExpression,
 								token),
 							c_fixName),
 						diagnostic);
@@ -332,7 +330,7 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 						createChangedDocument: token => ReplaceValueAsync(
 							context.Document,
 							ifNotNullInvocation.Parent,
-							ifStatement,
+							ifStatement.WithAdditionalAnnotations(Formatter.Annotation),
 							token),
 						c_fixName),
 					diagnostic);

--- a/src/Faithlife.Analyzers/InterpolatedStringAnalyzer.cs
+++ b/src/Faithlife.Analyzers/InterpolatedStringAnalyzer.cs
@@ -34,10 +34,12 @@ public sealed class InterpolatedStringAnalyzer : DiagnosticAnalyzer
 		var invocationOperation = (IInterpolatedStringOperation)context.Operation;
 		var foundDollarSign = false;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		if (!invocationOperation.Children.Any(child => child is IInterpolationOperation))
 			context.ReportDiagnostic(Diagnostic.Create(s_ruleUnnecessary, invocationOperation.Syntax.GetLocation()));
 
 		foreach (var child in invocationOperation.Children)
+#pragma warning restore CS0618 // Type or member is obsolete
 		{
 			if ((child as IInterpolatedStringTextOperation)?.Text.Syntax.ToFullString().EndsWith("$", StringComparison.Ordinal) ?? false)
 			{
@@ -55,7 +57,7 @@ public sealed class InterpolatedStringAnalyzer : DiagnosticAnalyzer
 	private static readonly DiagnosticDescriptor s_ruleDollar = new(
 		id: DiagnosticIdDollar,
 		title: "Unintentional ${} in interpolated strings",
-		messageFormat: "Avoid using ${} in interpolated strings.",
+		messageFormat: "Avoid using ${} in interpolated strings",
 		category: "Usage",
 		defaultSeverity: DiagnosticSeverity.Warning,
 		isEnabledByDefault: true,
@@ -64,7 +66,7 @@ public sealed class InterpolatedStringAnalyzer : DiagnosticAnalyzer
 	private static readonly DiagnosticDescriptor s_ruleUnnecessary = new(
 		id: DiagnosticIdUnnecessary,
 		title: "Unnecessary interpolated string",
-		messageFormat: "Avoid using an interpolated string where an equivalent literal string exists.",
+		messageFormat: "Avoid using an interpolated string where an equivalent literal string exists",
 		category: "Usage",
 		defaultSeverity: DiagnosticSeverity.Warning,
 		isEnabledByDefault: true,

--- a/src/Faithlife.Analyzers/LocalFunctionEventHandler.cs
+++ b/src/Faithlife.Analyzers/LocalFunctionEventHandler.cs
@@ -90,7 +90,7 @@ public class LocalFunctionEventHandler : DiagnosticAnalyzer
 	private static readonly DiagnosticDescriptor s_localFunctionRule = new(
 		id: LocalFunctionDiagnosticId,
 		title: "Local Functions as Event Handlers",
-		messageFormat: "Local function event handler.",
+		messageFormat: "Local function event handler",
 		category: "Usage",
 		defaultSeverity: DiagnosticSeverity.Warning,
 		isEnabledByDefault: true,
@@ -100,7 +100,7 @@ public class LocalFunctionEventHandler : DiagnosticAnalyzer
 	private static readonly DiagnosticDescriptor s_lambdaRule = new(
 		id: LambdaDiagnosticId,
 		title: "Lambda Expressions as Event Handlers",
-		messageFormat: "Lambda expression event handler.",
+		messageFormat: "Lambda expression event handler",
 		category: "Usage",
 		defaultSeverity: DiagnosticSeverity.Error,
 		isEnabledByDefault: true,

--- a/src/Faithlife.Analyzers/VerbatimStringAnalyzer.cs
+++ b/src/Faithlife.Analyzers/VerbatimStringAnalyzer.cs
@@ -44,7 +44,7 @@ public sealed class VerbatimStringAnalyzer : DiagnosticAnalyzer
 	private static readonly DiagnosticDescriptor s_rule = new(
 		id: DiagnosticId,
 		title: "Unnecessary use of verbatim string literal",
-		messageFormat: "Avoid using verbatim string literals without special characters.",
+		messageFormat: "Avoid using verbatim string literals without special characters",
 		category: "Usage",
 		defaultSeverity: DiagnosticSeverity.Warning,
 		isEnabledByDefault: true,

--- a/tests/Faithlife.Analyzers.Tests/DbConnectorCommandInterpolatedTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/DbConnectorCommandInterpolatedTests.cs
@@ -46,7 +46,7 @@ namespace TestApplication
 		var expected = new DiagnosticResult
 		{
 			Id = DbConnectorCommandInterpolatedAnalyzer.DiagnosticId,
-			Message = "Command should not be used with an interpolated string; use CommandFormat instead.",
+			Message = "Command should not be used with an interpolated string; use CommandFormat instead",
 			Severity = DiagnosticSeverity.Warning,
 			Locations = new[] { new DiagnosticResultLocation("Test0.cs", s_preambleLength + 8, 4) },
 		};

--- a/tests/Faithlife.Analyzers.Tests/Faithlife.Analyzers.Tests.csproj
+++ b/tests/Faithlife.Analyzers.Tests/Faithlife.Analyzers.Tests.csproj
@@ -1,18 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
+    <NoWarn>$(NoWarn);CA1515</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Faithlife.Analyzers.Tests/GetOrAddValueTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/GetOrAddValueTests.cs
@@ -51,9 +51,9 @@ namespace TestApplication
 		var expected = new DiagnosticResult
 		{
 			Id = GetOrAddValueAnalyzer.DiagnosticId,
-			Message = "GetOrAddValue() is not threadsafe and should not be used with ConcurrentDictionary; use GetOrAdd() instead.",
+			Message = "GetOrAddValue() is not threadsafe and should not be used with ConcurrentDictionary; use GetOrAdd() instead",
 			Severity = DiagnosticSeverity.Warning,
-			Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 8, invalidCall.Length - "GetOrAddValue".Length) },
+			Locations = new[] { new DiagnosticResultLocation("Test0.cs", s_preambleLength + 8, invalidCall.Length - "GetOrAddValue".Length) },
 		};
 
 		VerifyCSharpDiagnostic(brokenProgram, expected);
@@ -84,9 +84,9 @@ namespace TestApplication
 		var expected = new DiagnosticResult
 		{
 			Id = GetOrAddValueAnalyzer.DiagnosticId,
-			Message = "GetOrAddValue() is not threadsafe and should not be used with ConcurrentDictionary; use GetOrAdd() instead.",
+			Message = "GetOrAddValue() is not threadsafe and should not be used with ConcurrentDictionary; use GetOrAdd() instead",
 			Severity = DiagnosticSeverity.Warning,
-			Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 8, invalidCall.Length - "GetOrAddValue".Length) },
+			Locations = new[] { new DiagnosticResultLocation("Test0.cs", s_preambleLength + 8, invalidCall.Length - "GetOrAddValue".Length) },
 		};
 
 		VerifyCSharpDiagnostic(brokenProgram, expected);
@@ -110,5 +110,5 @@ namespace Libronix.Utility
 }
 ";
 
-	private static readonly int c_preambleLength = c_preamble.Split('\n').Length;
+	private static readonly int s_preambleLength = c_preamble.Split('\n').Length;
 }

--- a/tests/Faithlife.Analyzers.Tests/Helpers/DiagnosticVerifier.Helper.cs
+++ b/tests/Faithlife.Analyzers.Tests/Helpers/DiagnosticVerifier.Helper.cs
@@ -161,7 +161,6 @@ public abstract partial class DiagnosticVerifier
 			.CurrentSolution
 			.AddProject(projectId, TestProjectName, TestProjectName, language)
 			.WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
-			.WithProjectParseOptions(projectId, new CSharpParseOptions(LanguageVersion.Latest))
 			.AddMetadataReferences(projectId, s_metadataReferences);
 
 		int count = 0;

--- a/tests/Faithlife.Analyzers.Tests/Helpers/DiagnosticVerifier.Helper.cs
+++ b/tests/Faithlife.Analyzers.Tests/Helpers/DiagnosticVerifier.Helper.cs
@@ -161,6 +161,7 @@ public abstract partial class DiagnosticVerifier
 			.CurrentSolution
 			.AddProject(projectId, TestProjectName, TestProjectName, language)
 			.WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+			.WithProjectParseOptions(projectId, new CSharpParseOptions(LanguageVersion.Latest))
 			.AddMetadataReferences(projectId, s_metadataReferences);
 
 		int count = 0;

--- a/tests/Faithlife.Analyzers.Tests/IfNotNullTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/IfNotNullTests.cs
@@ -229,7 +229,7 @@ public sealed class IfNotNullTests : CodeFixVerifier
 		"var result = possiblyNull is ReferenceThing ? new { Property = \"value\" } : new { Property = \"other value\" };")]
 	public void SimpleMethodCall(string possiblyNull, string call, string fixedCall)
 	{
-		string createProgram(string actualCall) =>
+		string CreateProgram(string actualCall) =>
 			c_preamble + @"
 namespace TestProgram
 {
@@ -248,14 +248,14 @@ namespace TestProgram
 			Id = IfNotNullAnalyzer.DiagnosticId,
 			Message = "Prefer modern language features over IfNotNull usage",
 			Severity = DiagnosticSeverity.Info,
-			Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 8, 17) },
+			Locations = new[] { new DiagnosticResultLocation("Test0.cs", s_preambleLength + 8, 17) },
 		};
 
-		string invalidProgram = createProgram(call);
+		string invalidProgram = CreateProgram(call);
 
 		VerifyCSharpDiagnostic(invalidProgram, expected);
 
-		string validProgram = createProgram(fixedCall).Replace("using Libronix.Utility.IfNotNull;\n", "", StringComparison.Ordinal);
+		string validProgram = CreateProgram(fixedCall).Replace("using Libronix.Utility.IfNotNull;\n", "", StringComparison.Ordinal);
 
 		VerifyCSharpFix(invalidProgram, validProgram);
 	}
@@ -282,7 +282,7 @@ namespace TestProgram
 		17, 17)]
 	public void MultipleMethodCalls(string possiblyNull, string call, string fixedCall, int firstColumn, int secondColumn)
 	{
-		string createProgram(string actualCall) =>
+		string CreateProgram(string actualCall) =>
 			c_preamble + @"
 namespace TestProgram
 {
@@ -302,14 +302,14 @@ namespace TestProgram
 				Id = IfNotNullAnalyzer.DiagnosticId,
 				Message = "Prefer modern language features over IfNotNull usage",
 				Severity = DiagnosticSeverity.Info,
-				Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 8, column) },
+				Locations = new[] { new DiagnosticResultLocation("Test0.cs", s_preambleLength + 8, column) },
 			};
 
-		string invalidProgram = createProgram(call);
+		string invalidProgram = CreateProgram(call);
 
 		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnosticAtColumn(firstColumn), CreateDiagnosticAtColumn(secondColumn));
 
-		string validProgram = createProgram(fixedCall).Replace("using Libronix.Utility.IfNotNull;\n", "", StringComparison.Ordinal);
+		string validProgram = CreateProgram(fixedCall).Replace("using Libronix.Utility.IfNotNull;\n", "", StringComparison.Ordinal);
 
 		VerifyCSharpFix(invalidProgram, validProgram);
 	}
@@ -332,7 +332,7 @@ namespace TestProgram
 		"if (possiblyNull is ValueThing x)\n\t\t\t\tx.Method();\n\t\t\telse\n\t\t\t\tthrow new InvalidOperationException();")]
 	public void VoidInvocation(string possiblyNull, string call, string fixedCall)
 	{
-		string createProgram(string actualCall) =>
+		string CreateProgram(string actualCall) =>
 			c_preamble + @"
 namespace TestProgram
 {
@@ -351,20 +351,20 @@ namespace TestProgram
 			Id = IfNotNullAnalyzer.DiagnosticId,
 			Message = "Prefer modern language features over IfNotNull usage",
 			Severity = DiagnosticSeverity.Info,
-			Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 8, 4) },
+			Locations = new[] { new DiagnosticResultLocation("Test0.cs", s_preambleLength + 8, 4) },
 		};
 
-		string invalidProgram = createProgram(call);
+		string invalidProgram = CreateProgram(call);
 
 		VerifyCSharpDiagnostic(invalidProgram, expected);
 
 		// The fixer should decline to make any modifications to unsupported calls.
-		VerifyCSharpFix(invalidProgram, fixedCall is null ? invalidProgram : createProgram(fixedCall).Replace("using Libronix.Utility.IfNotNull;\n", "", StringComparison.Ordinal));
+		VerifyCSharpFix(invalidProgram, fixedCall is null ? invalidProgram : CreateProgram(fixedCall).Replace("using Libronix.Utility.IfNotNull;\n", "", StringComparison.Ordinal));
 	}
 
 	public void NonLocalInvocation()
 	{
-		string createProgram(string actualCall) =>
+		string CreateProgram(string actualCall) =>
 			c_preamble + @"
 namespace TestProgram
 {
@@ -384,15 +384,15 @@ namespace TestProgram
 			Id = IfNotNullAnalyzer.DiagnosticId,
 			Message = "Prefer modern language features over IfNotNull usage",
 			Severity = DiagnosticSeverity.Info,
-			Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 8, 4) },
+			Locations = new[] { new DiagnosticResultLocation("Test0.cs", s_preambleLength + 8, 4) },
 		};
 
-		string invalidProgram = createProgram("OnAction.IfNotNull(x => x(), () => throw new InvalidOperationException());");
+		string invalidProgram = CreateProgram("OnAction.IfNotNull(x => x(), () => throw new InvalidOperationException());");
 
 		VerifyCSharpDiagnostic(invalidProgram, expected);
 
 		// Ensure that invocations on identifiers that are *not* local variables receive a local variable definition.
-		VerifyCSharpFix(invalidProgram, createProgram(@"if (OnAction is Action x)
+		VerifyCSharpFix(invalidProgram, CreateProgram(@"if (OnAction is Action x)
 				x();
 			else
 				throw new InvalidOperationException();").Replace("using Libronix.Utility.IfNotNull;\n", "", StringComparison.Ordinal));
@@ -412,7 +412,7 @@ namespace TestProgram
 		"var result = possiblyNull.IfNotNull(x => new[] { x });")]
 	public void UnhandledInvocation(string possiblyNull, string call)
 	{
-		string createProgram(string actualCall) =>
+		string CreateProgram(string actualCall) =>
 			c_preamble + @"
 namespace TestProgram
 {
@@ -431,10 +431,10 @@ namespace TestProgram
 			Id = IfNotNullAnalyzer.DiagnosticId,
 			Message = "Prefer modern language features over IfNotNull usage",
 			Severity = DiagnosticSeverity.Info,
-			Locations = new[] { new DiagnosticResultLocation("Test0.cs", c_preambleLength + 8, 17) },
+			Locations = new[] { new DiagnosticResultLocation("Test0.cs", s_preambleLength + 8, 17) },
 		};
 
-		string invalidProgram = createProgram(call);
+		string invalidProgram = CreateProgram(call);
 
 		VerifyCSharpDiagnostic(invalidProgram, expected);
 
@@ -493,5 +493,5 @@ namespace TestProgram
 }
 ";
 
-	private static readonly int c_preambleLength = c_preamble.Split('\n').Length;
+	private static readonly int s_preambleLength = c_preamble.Split('\n').Length;
 }

--- a/tests/Faithlife.Analyzers.Tests/InterpolatedStringTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/InterpolatedStringTests.cs
@@ -61,7 +61,7 @@ namespace TestApplication
 		VerifyCSharpDiagnostic(invalidProgram, new DiagnosticResult
 		{
 			Id = InterpolatedStringAnalyzer.DiagnosticIdDollar,
-			Message = "Avoid using ${} in interpolated strings.",
+			Message = "Avoid using ${} in interpolated strings",
 			Severity = DiagnosticSeverity.Warning,
 			Locations = new[] { new DiagnosticResultLocation("Test0.cs", 9, 20) },
 		});
@@ -86,14 +86,14 @@ namespace TestApplication
 			new DiagnosticResult
 			{
 				Id = InterpolatedStringAnalyzer.DiagnosticIdDollar,
-				Message = "Avoid using ${} in interpolated strings.",
+				Message = "Avoid using ${} in interpolated strings",
 				Severity = DiagnosticSeverity.Warning,
 				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 9, 20) },
 			},
 			new DiagnosticResult
 			{
 				Id = InterpolatedStringAnalyzer.DiagnosticIdDollar,
-				Message = "Avoid using ${} in interpolated strings.",
+				Message = "Avoid using ${} in interpolated strings",
 				Severity = DiagnosticSeverity.Warning,
 				Locations = new[] { new DiagnosticResultLocation("Test0.cs", 9, 26) },
 			});
@@ -117,7 +117,7 @@ namespace TestApplication
 		VerifyCSharpDiagnostic(invalidProgram, new DiagnosticResult
 		{
 			Id = InterpolatedStringAnalyzer.DiagnosticIdDollar,
-			Message = "Avoid using ${} in interpolated strings.",
+			Message = "Avoid using ${} in interpolated strings",
 			Severity = DiagnosticSeverity.Warning,
 			Locations = new[] { new DiagnosticResultLocation("Test0.cs", 9, 20) },
 		});
@@ -140,7 +140,7 @@ namespace TestApplication
 		VerifyCSharpDiagnostic(invalidProgram, new DiagnosticResult
 		{
 			Id = InterpolatedStringAnalyzer.DiagnosticIdUnnecessary,
-			Message = "Avoid using an interpolated string where an equivalent literal string exists.",
+			Message = "Avoid using an interpolated string where an equivalent literal string exists",
 			Severity = DiagnosticSeverity.Warning,
 			Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 17) },
 		});
@@ -163,7 +163,7 @@ namespace TestApplication
 		VerifyCSharpDiagnostic(invalidProgram, new DiagnosticResult
 		{
 			Id = InterpolatedStringAnalyzer.DiagnosticIdUnnecessary,
-			Message = "Avoid using an interpolated string where an equivalent literal string exists.",
+			Message = "Avoid using an interpolated string where an equivalent literal string exists",
 			Severity = DiagnosticSeverity.Warning,
 			Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 17) },
 		});

--- a/tests/Faithlife.Analyzers.Tests/LocalFunctionEventHandlerTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/LocalFunctionEventHandlerTests.cs
@@ -31,7 +31,7 @@ public class LocalFunctionEventHandlerTests : CodeFixVerifier
 		{
 			Id = LocalFunctionEventHandler.LocalFunctionDiagnosticId,
 			Severity = DiagnosticSeverity.Warning,
-			Message = "Local function event handler.",
+			Message = "Local function event handler",
 			Locations = new[] { new DiagnosticResultLocation("Test0.cs", 7, 3) },
 		});
 	}
@@ -101,7 +101,7 @@ public class LocalFunctionEventHandlerTests : CodeFixVerifier
 		{
 			Id = LocalFunctionEventHandler.LambdaDiagnosticId,
 			Severity = DiagnosticSeverity.Error,
-			Message = "Lambda expression event handler.",
+			Message = "Lambda expression event handler",
 			Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 3) },
 		});
 	}

--- a/tests/Faithlife.Analyzers.Tests/VerbatimStringTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/VerbatimStringTests.cs
@@ -45,7 +45,7 @@ namespace TestApplication
 		VerifyCSharpDiagnostic(invalidProgram, new DiagnosticResult
 		{
 			Id = VerbatimStringAnalyzer.DiagnosticId,
-			Message = "Avoid using verbatim string literals without special characters.",
+			Message = "Avoid using verbatim string literals without special characters",
 			Severity = DiagnosticSeverity.Warning,
 			Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 4) },
 		});
@@ -68,7 +68,7 @@ namespace TestApplication
 		VerifyCSharpDiagnostic(invalidProgram, new DiagnosticResult
 		{
 			Id = VerbatimStringAnalyzer.DiagnosticId,
-			Message = "Avoid using verbatim string literals without special characters.",
+			Message = "Avoid using verbatim string literals without special characters",
 			Severity = DiagnosticSeverity.Warning,
 			Locations = new[] { new DiagnosticResultLocation("Test0.cs", 8, 4) },
 		});

--- a/tools/Build/Build.csproj
+++ b/tools/Build/Build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As long as Faithlife.Analyzers is being actively used, we should keep the code up-to-date and building with the latest dependencies.

Notes:

* Suppressed one Obsolete warning in code that might need to be fixed (for interpolated string handling) anyway.
* Add `roslyn_correctness.assembly_reference_validation = relaxed` to avoid RS1038: https://github.com/dotnet/roslyn-analyzers/blob/main/docs/rules/RS1022.md.
* Update .NET SDK to 9.0 to avoid CS8032 errors (in Release builds) about System.Collections.Immutable v9.0.0.
* Drop trailing periods from messages to comply with RS1032.