### PR TITLE
Add analyzer to detect using interpolated strings with Libronix Logger (FL0024)

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -9,7 +9,7 @@ Prefix the description of the change with `[major]`, `[minor]`, or `[patch]` in 
 New analyzers are considered "minor" changes (even though adding a new analyzer is likely to generate warnings
 or errors for existing code when the package is upgraded).
 
-* `[minor]` Fix FL0024 code fix provider to properly find interpolated string expressions within argument nodes.
+* `[minor]` Add [FL0024](https://github.com/Faithlife/FaithlifeAnalyzers/wiki/FL0024): Use composite format string instead of interpolated string with Libronix Logger methods.
 
 ## 1.6.0 Beta 2
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -9,6 +9,8 @@ Prefix the description of the change with `[major]`, `[minor]`, or `[patch]` in 
 New analyzers are considered "minor" changes (even though adding a new analyzer is likely to generate warnings
 or errors for existing code when the package is upgraded).
 
+* `[minor]` Fix FL0024 code fix provider to properly find interpolated string expressions within argument nodes.
+
 ## 1.6.0 Beta 2
 
 * Add [FL0023](https://github.com/Faithlife/FaithlifeAnalyzers/wiki/FL0023): Avoid obsolete `Logos.Common.Logging.Extensions.LoggerExtensions` methods.

--- a/src/Faithlife.Analyzers/LoggerInterpolatedStringAnalyzer.cs
+++ b/src/Faithlife.Analyzers/LoggerInterpolatedStringAnalyzer.cs
@@ -1,0 +1,82 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Faithlife.Analyzers;
+
+/// <summary>
+/// Detects interpolated strings passed directly to Libronix.Utility.Logging.Logger methods and suggests
+/// converting them to composite format strings with arguments (e.g., $"X {y}" -> "X {0}", y).
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class LoggerInterpolatedStringAnalyzer : DiagnosticAnalyzer
+{
+	public override void Initialize(AnalysisContext context)
+	{
+		context.EnableConcurrentExecution();
+		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+		context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+	}
+
+	public const string DiagnosticId = "FL0024";
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [s_rule];
+
+	private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+	{
+		var invocation = (InvocationExpressionSyntax) context.Node;
+		var argumentList = invocation.ArgumentList;
+		if (argumentList.Arguments.Count == 0)
+			return;
+
+		var args = argumentList.Arguments;
+
+		// Only inspect first argument (message template).
+		if (args[0].Expression is not InterpolatedStringExpressionSyntax interpolated)
+			return;
+
+		// Ignore if there are no interpolation holes (FL0014 already handles empty interpolation cases).
+		if (interpolated.Contents.All(c => c is InterpolatedStringTextSyntax))
+			return;
+
+		// Resolve symbol.
+		if (context.SemanticModel.GetSymbolInfo(invocation.Expression).Symbol is not IMethodSymbol methodSymbol)
+			return;
+
+		if (!IsLoggerMethod(methodSymbol))
+			return;
+
+		// If caller already supplies additional arguments that could be a params array, allow fix anyway,
+		// but skip if second argument is explicitly an array creation to avoid ambiguity.
+		if (args.Count > 1 && args[1].Expression is (ArrayCreationExpressionSyntax or ImplicitArrayCreationExpressionSyntax))
+			return;
+
+		context.ReportDiagnostic(Diagnostic.Create(s_rule, args[0].GetLocation()));
+	}
+
+	private static bool IsLoggerMethod(IMethodSymbol method)
+	{
+		// Require containing type Libronix.Utility.Logging.Logger
+		var containing = method.ContainingType;
+		if (containing is null)
+			return false;
+		if (containing.Name != "Logger")
+			return false;
+		if (containing.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) != "global::Libronix.Utility.Logging.Logger")
+			return false;
+
+		return method.Name is "Debug" or "Info" or "Warn" or "Error" or "Fatal" or "Write";
+	}
+
+	private static readonly DiagnosticDescriptor s_rule = new(
+		id: DiagnosticId,
+		title: "Use composite format string instead of interpolated string",
+		messageFormat: "Replace interpolated string with composite format string arguments",
+		category: "Usage",
+		defaultSeverity: DiagnosticSeverity.Info,
+		isEnabledByDefault: true,
+		helpLinkUri: $"https://github.com/Faithlife/FaithlifeAnalyzers/wiki/{DiagnosticId}");
+}

--- a/src/Faithlife.Analyzers/LoggerInterpolatedStringCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/LoggerInterpolatedStringCodeFixProvider.cs
@@ -1,0 +1,115 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Faithlife.Analyzers;
+
+/// <summary>
+/// Code fix converting an interpolated string argument to a composite format with additional arguments.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(LoggerInterpolatedStringCodeFixProvider)), Shared]
+public sealed class LoggerInterpolatedStringCodeFixProvider : CodeFixProvider
+{
+	public override ImmutableArray<string> FixableDiagnosticIds => [LoggerInterpolatedStringAnalyzer.DiagnosticId];
+
+	public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+	public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+	{
+		var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+		if (root is null)
+			return;
+
+		var diagnostic = context.Diagnostics.First();
+		var node = root.FindNode(diagnostic.Location.SourceSpan);
+
+		// The diagnostic is reported at the argument location, so we need to find the interpolated string
+		// either directly (if the node is the interpolated string) or within the node's descendants
+		var interpolated = node as InterpolatedStringExpressionSyntax ??
+			node.DescendantNodesAndSelf().OfType<InterpolatedStringExpressionSyntax>().FirstOrDefault();
+
+		if (interpolated is null)
+			return;
+
+		context.RegisterCodeFix(
+			CodeAction.Create(
+				title: "Convert to composite format string",
+				createChangedDocument: c => ApplyFixAsync(context.Document, interpolated, c),
+				equivalenceKey: "convert-to-composite-format"),
+			diagnostic);
+	}
+
+	private static async Task<Document> ApplyFixAsync(Document document, InterpolatedStringExpressionSyntax interpolated, CancellationToken ct)
+	{
+		var root = await document.GetSyntaxRootAsync(ct).ConfigureAwait(false);
+		if (root is null)
+			return document;
+
+		var invocation = interpolated.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+		if (invocation is null)
+			return document;
+
+		var (formatLiteral, argumentExpressions) = BuildFormatLiteral(interpolated);
+
+		// Replace first argument expression with a string literal.
+		var originalArgs = invocation.ArgumentList.Arguments;
+		var newFirstArg = originalArgs[0].WithExpression(
+			SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(formatLiteral)));
+
+		// Add new arguments for each interpolation hole.
+		SeparatedSyntaxList<ArgumentSyntax> newArgList;
+		if (argumentExpressions.Count == 0)
+		{
+			newArgList = SyntaxFactory.SeparatedList([newFirstArg]);
+		}
+		else
+		{
+			var list = originalArgs.ToList();
+			list[0] = newFirstArg;
+			list.AddRange(argumentExpressions.Select(SyntaxFactory.Argument));
+			newArgList = SyntaxFactory.SeparatedList(list);
+		}
+
+		var newInvocation = invocation.WithArgumentList(invocation.ArgumentList.WithArguments(newArgList));
+		var newRoot = root.ReplaceNode(invocation, newInvocation);
+		return document.WithSyntaxRoot(newRoot);
+	}
+
+	private static (string Literal, List<ExpressionSyntax> Args) BuildFormatLiteral(InterpolatedStringExpressionSyntax interpolated)
+	{
+		var sb = new StringBuilder();
+		var args = new List<ExpressionSyntax>();
+		var index = 0;
+
+		foreach (var content in interpolated.Contents)
+		{
+			switch (content)
+			{
+				case InterpolatedStringTextSyntax text:
+					sb.Append(text.TextToken.ValueText);
+					break;
+
+				case InterpolationSyntax hole:
+				{
+					var alignment = hole.AlignmentClause?.ToString() ?? ""; // includes comma
+					var format = hole.FormatClause?.ToString() ?? "";       // includes colon
+					sb.Append('{')
+					  .Append(index)
+					  .Append(alignment)
+					  .Append(format)
+					  .Append('}');
+					args.Add(hole.Expression.WithoutTrivia());
+					index++;
+					break;
+				}
+			}
+		}
+
+		return (sb.ToString(), args);
+	}
+}

--- a/tests/Faithlife.Analyzers.Tests/LoggerInterpolatedStringTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/LoggerInterpolatedStringTests.cs
@@ -56,7 +56,7 @@ internal sealed class LoggerInterpolatedStringTests : CodeFixVerifier
 			Id = LoggerInterpolatedStringAnalyzer.DiagnosticId,
 			Message = "Replace interpolated string with composite format string arguments",
 			Severity = DiagnosticSeverity.Info,
-			Locations = [new("Test0.cs", 26, 18)],
+			Locations = [new("Test0.cs", 39, 18)],
 		};
 
 		VerifyCSharpDiagnostic(invalidProgram, expected);
@@ -106,7 +106,7 @@ internal sealed class LoggerInterpolatedStringTests : CodeFixVerifier
 			Id = LoggerInterpolatedStringAnalyzer.DiagnosticId,
 			Message = "Replace interpolated string with composite format string arguments",
 			Severity = DiagnosticSeverity.Info,
-			Locations = [new("Test0.cs", 26, 19)],
+			Locations = [new("Test0.cs", 39, 19)],
 		};
 
 		VerifyCSharpDiagnostic(invalidProgram, expected);
@@ -140,6 +140,15 @@ internal sealed class LoggerInterpolatedStringTests : CodeFixVerifier
 
 		namespace Libronix.Utility.Logging
 		{
+			public enum LogLevel
+			{
+				Debug,
+				Info,
+				Warn,
+				Error,
+				Fatal,
+			}
+
 			public class Logger
 			{
 				public void Debug(string message) => throw new System.NotImplementedException();
@@ -150,6 +159,10 @@ internal sealed class LoggerInterpolatedStringTests : CodeFixVerifier
 				public void Warn(string message, params object[] args) => throw new System.NotImplementedException();
 				public void Error(string message) => throw new System.NotImplementedException();
 				public void Error(string message, params object[] args) => throw new System.NotImplementedException();
+				public void Fatal(string message) => throw new System.NotImplementedException();
+				public void Fatal(string message, params object[] args) => throw new System.NotImplementedException();
+				public void Write(LogLevel level, string message) => throw new System.NotImplementedException();
+				public void Write(LogLevel level, string message, params object[] args) => throw new System.NotImplementedException();
 			}
 		}
 		""";

--- a/tests/Faithlife.Analyzers.Tests/LoggerInterpolatedStringTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/LoggerInterpolatedStringTests.cs
@@ -1,0 +1,156 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Framework;
+
+namespace Faithlife.Analyzers.Tests;
+
+[TestFixture]
+internal sealed class LoggerInterpolatedStringTests : CodeFixVerifier
+{
+	[Test]
+	public void ValidLiteral()
+	{
+		const string validProgram = $$"""
+			{{c_preamble}}
+
+			namespace TestApplication
+			{
+				internal static class TestClass
+				{
+					private static Logger m_logger = null!;
+
+					public static void UtilityMethod(string x)
+					{
+						m_logger.Warn("Search query failed.");
+					}
+				}
+			}
+			""";
+
+		VerifyCSharpDiagnostic(validProgram);
+	}
+
+	[Test]
+	public void InvalidSimpleInterpolation()
+	{
+		const string invalidProgram = $$"""
+			{{c_preamble}}
+
+			namespace TestApplication
+			{
+				internal static class TestClass
+				{
+					private static Logger m_logger = null!;
+
+					public static void UtilityMethod(string errorMessage)
+					{
+						m_logger.Warn($"Search query failed: {errorMessage}");
+					}
+				}
+			}
+			""";
+
+		var expected = new DiagnosticResult
+		{
+			Id = LoggerInterpolatedStringAnalyzer.DiagnosticId,
+			Message = "Replace interpolated string with composite format string arguments",
+			Severity = DiagnosticSeverity.Info,
+			Locations = [new("Test0.cs", 26, 18)],
+		};
+
+		VerifyCSharpDiagnostic(invalidProgram, expected);
+
+		const string fixedProgram = $$"""
+			{{c_preamble}}
+
+			namespace TestApplication
+			{
+				internal static class TestClass
+				{
+					private static Logger m_logger = null!;
+
+					public static void UtilityMethod(string errorMessage)
+					{
+						m_logger.Warn("Search query failed: {0}", errorMessage);
+					}
+				}
+			}
+			""";
+
+		VerifyCSharpFix(invalidProgram, fixedProgram, 0);
+	}
+
+	[Test]
+	public void InvalidWithFormatAndAlignment()
+	{
+		const string invalidProgram = $$"""
+			{{c_preamble}}
+
+			namespace TestApplication
+			{
+				internal static class TestClass
+				{
+					private static Logger m_logger = null!;
+
+					public static void UtilityMethod(int code, double percent)
+					{
+						m_logger.Error($"Code={code,4:D2} Percent={percent:0.00}%");
+					}
+				}
+			}
+			""";
+
+		var expected = new DiagnosticResult
+		{
+			Id = LoggerInterpolatedStringAnalyzer.DiagnosticId,
+			Message = "Replace interpolated string with composite format string arguments",
+			Severity = DiagnosticSeverity.Info,
+			Locations = [new("Test0.cs", 26, 19)],
+		};
+
+		VerifyCSharpDiagnostic(invalidProgram, expected);
+
+		const string fixedProgram = $$"""
+			{{c_preamble}}
+
+			namespace TestApplication
+			{
+				internal static class TestClass
+				{
+					private static Logger m_logger = null!;
+
+					public static void UtilityMethod(int code, double percent)
+					{
+						m_logger.Error("Code={0,4:D2} Percent={1:0.00}%", code, percent);
+					}
+				}
+			}
+			""";
+
+		VerifyCSharpFix(invalidProgram, fixedProgram, 0);
+	}
+
+	protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new LoggerInterpolatedStringAnalyzer();
+
+	protected override CodeFixProvider GetCSharpCodeFixProvider() => new LoggerInterpolatedStringCodeFixProvider();
+
+	private const string c_preamble = """
+		using Libronix.Utility.Logging;
+
+		namespace Libronix.Utility.Logging
+		{
+			public class Logger
+			{
+				public void Debug(string message) => throw new System.NotImplementedException();
+				public void Debug(string message, params object[] args) => throw new System.NotImplementedException();
+				public void Info(string message) => throw new System.NotImplementedException();
+				public void Info(string message, params object[] args) => throw new System.NotImplementedException();
+				public void Warn(string message) => throw new System.NotImplementedException();
+				public void Warn(string message, params object[] args) => throw new System.NotImplementedException();
+				public void Error(string message) => throw new System.NotImplementedException();
+				public void Error(string message, params object[] args) => throw new System.NotImplementedException();
+			}
+		}
+		""";
+}


### PR DESCRIPTION
# FL0024: Use composite format string instead of interpolated string

## Summary

Detects interpolated strings in `Libronix.Utility.Logging.Logger` methods and converts them to composite format strings with arguments.

## Example

### Before
```csharp
m_logger.Warn($"Search query failed: {errorMessage}");
m_logger.Error($"Code={code,4:D2} Percent={percent:0.00}%");
```

### After
```csharp
m_logger.Warn("Search query failed: {0}", errorMessage);
m_logger.Error("Code={0,4:D2} Percent={1:0.00}%", code, percent);
```

## Rationale

Interpolated strings in logger methods cause performance issues because they create formatted strings immediately, even when logging is disabled. Composite format strings allow the logging framework to skip formatting when the log level is disabled.

## Severity

**Info** - Suggests performance optimization for logger calls.
