### PR TITLE
Add InvariantConvert analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ dotnet_diagnostic.FL0009.severity = none
 | [FL0021](docs/FL0021.md) | Use null propagation |
 | [FL0022](docs/FL0022.md) | Use AsyncMethodContext.WorkState |
 | [FL0023](docs/FL0023.md) | Replace obsolete Logos.Common.Logging.Extensions extension methods |
+| [FL0026](docs/FL0026.md) | Use `InvariantConvert` |
 
 ## How to Help
 

--- a/docs/FL0026.md
+++ b/docs/FL0026.md
@@ -1,61 +1,35 @@
 # FL0026: Use `InvariantConvert`
 
-## Summary
+`InvariantConvert` is the preferred way to parse and format values that use invariant-culture string representations.
 
-Detects invariant-culture conversions that can use `Libronix.Utility.Invariant.InvariantConvert`.
+When this warning appears, add `using Libronix.Utility.Invariant;` and replace the invariant-culture call with the matching `InvariantConvert` helper.
 
-This analyzer only reports diagnostics when `Libronix.Utility.Invariant.InvariantConvert` is available in the compilation.
+## Suggested Fixes
 
-## Examples
+* Replace `bool.Parse(text)` with `InvariantConvert.ParseBoolean(text)`.
+* Replace `int.Parse(text, CultureInfo.InvariantCulture)` with `InvariantConvert.ParseInt32(text)`.
+* Replace `double.Parse(text, CultureInfo.InvariantCulture)` with `InvariantConvert.ParseDouble(text)`.
+* Replace `long.Parse(text, CultureInfo.InvariantCulture)` with `InvariantConvert.ParseInt64(text)`.
+* Replace `value.ToString(CultureInfo.InvariantCulture)` with `value.ToInvariantString()`.
 
-### Parse
-
-```csharp
-var startIndex = int.Parse(splitRange[0], CultureInfo.InvariantCulture);
-```
-
-Use:
+For `TryParse`, use the nullable result returned by `InvariantConvert`:
 
 ```csharp
-var startIndex = InvariantConvert.ParseInt32(splitRange[0]);
+if (int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
 ```
 
-### TryParse
+becomes:
 
 ```csharp
-if (!int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var hours))
-	return false;
+if (InvariantConvert.TryParseInt32(text) is { } value)
 ```
 
-Use:
+Negated `TryParse` checks use `is not { }`:
 
 ```csharp
-if (InvariantConvert.TryParseInt32(parts[0]) is not { } hours)
-	return false;
+if (InvariantConvert.TryParseInt32(text) is not { } value)
 ```
 
-### ToString
+## Limitations
 
-```csharp
-var text = value.ToString(CultureInfo.InvariantCulture);
-```
-
-Use:
-
-```csharp
-var text = value.ToInvariantString();
-```
-
-## Supported conversions
-
-* `bool.Parse` and `bool.TryParse`
-* `int.Parse` and `int.TryParse` with `CultureInfo.InvariantCulture` and `NumberStyles.Integer`
-* `double.Parse` and `double.TryParse` with `CultureInfo.InvariantCulture` and `NumberStyles.Float`
-* `long.Parse` and `long.TryParse` with `CultureInfo.InvariantCulture` and `NumberStyles.Integer`
-* `ToString(CultureInfo.InvariantCulture)` for `bool`, `double`, `int`, and `long`
-
-`NumberStyles.None` is not reported because replacing it with `InvariantConvert` would broaden accepted input.
-
-## Severity
-
-**Info** - Suggests the standard Faithlife invariant conversion helpers when Libronix.Utility is already referenced.
+This analyzer only reports diagnostics when `Libronix.Utility.Invariant.InvariantConvert` is available. `NumberStyles.None` is not reported because `InvariantConvert` accepts the standard invariant styles for each supported type.

--- a/docs/FL0026.md
+++ b/docs/FL0026.md
@@ -1,0 +1,61 @@
+# FL0026: Use `InvariantConvert`
+
+## Summary
+
+Detects invariant-culture conversions that can use `Libronix.Utility.Invariant.InvariantConvert`.
+
+This analyzer only reports diagnostics when `Libronix.Utility.Invariant.InvariantConvert` is available in the compilation.
+
+## Examples
+
+### Parse
+
+```csharp
+var startIndex = int.Parse(splitRange[0], CultureInfo.InvariantCulture);
+```
+
+Use:
+
+```csharp
+var startIndex = InvariantConvert.ParseInt32(splitRange[0]);
+```
+
+### TryParse
+
+```csharp
+if (!int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var hours))
+	return false;
+```
+
+Use:
+
+```csharp
+if (InvariantConvert.TryParseInt32(parts[0]) is not { } hours)
+	return false;
+```
+
+### ToString
+
+```csharp
+var text = value.ToString(CultureInfo.InvariantCulture);
+```
+
+Use:
+
+```csharp
+var text = value.ToInvariantString();
+```
+
+## Supported conversions
+
+* `bool.Parse` and `bool.TryParse`
+* `int.Parse` and `int.TryParse` with `CultureInfo.InvariantCulture` and `NumberStyles.Integer`
+* `double.Parse` and `double.TryParse` with `CultureInfo.InvariantCulture` and `NumberStyles.Float`
+* `long.Parse` and `long.TryParse` with `CultureInfo.InvariantCulture` and `NumberStyles.Integer`
+* `ToString(CultureInfo.InvariantCulture)` for `bool`, `double`, `int`, and `long`
+
+`NumberStyles.None` is not reported because replacing it with `InvariantConvert` would broaden accepted input.
+
+## Severity
+
+**Info** - Suggests the standard Faithlife invariant conversion helpers when Libronix.Utility is already referenced.

--- a/src/Faithlife.Analyzers/InvariantConvertAnalyzer.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertAnalyzer.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Faithlife.Analyzers;
@@ -11,11 +13,290 @@ public sealed class InvariantConvertAnalyzer : DiagnosticAnalyzer
 	{
 		context.EnableConcurrentExecution();
 		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+		context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
+		{
+			if (!HasInvariantConvert(compilationStartAnalysisContext.Compilation))
+				return;
+
+			compilationStartAnalysisContext.RegisterSyntaxNodeAction(AnalyzeSyntax, SyntaxKind.InvocationExpression);
+		});
+	}
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [s_rule];
+
+	internal static bool HasInvariantConvert(Compilation compilation) =>
+		compilation.GetTypeByMetadataName(c_invariantConvertMetadataName) is { } invariantConvertType &&
+		HasMethod(invariantConvertType, "ParseBoolean") &&
+		HasMethod(invariantConvertType, "ParseDouble") &&
+		HasMethod(invariantConvertType, "ParseInt32") &&
+		HasMethod(invariantConvertType, "ParseInt64") &&
+		HasMethod(invariantConvertType, "TryParseBoolean") &&
+		HasMethod(invariantConvertType, "TryParseDouble") &&
+		HasMethod(invariantConvertType, "TryParseInt32") &&
+		HasMethod(invariantConvertType, "TryParseInt64") &&
+		HasMethod(invariantConvertType, "ToInvariantString");
+
+	internal static InvariantConvertMatch? TryCreateMatch(InvocationExpressionSyntax invocation, SemanticModel semanticModel, CancellationToken cancellationToken)
+	{
+		if (!HasInvariantConvert(semanticModel.Compilation))
+			return null;
+
+		if (semanticModel.GetSymbolInfo(invocation.Expression, cancellationToken).Symbol is not IMethodSymbol methodSymbol)
+			return null;
+
+		return TryCreateParseMatch(invocation, methodSymbol, semanticModel, cancellationToken) ??
+			TryCreateTryParseMatch(invocation, methodSymbol, semanticModel, cancellationToken) ??
+			TryCreateToStringMatch(invocation, methodSymbol, semanticModel, cancellationToken);
+	}
+
+	private static void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
+	{
+		var invocation = (InvocationExpressionSyntax) context.Node;
+		if (TryCreateMatch(invocation, context.SemanticModel, context.CancellationToken) is not null)
+			context.ReportDiagnostic(Diagnostic.Create(s_rule, invocation.GetLocation()));
+	}
+
+	private static InvariantConvertMatch? TryCreateParseMatch(InvocationExpressionSyntax invocation, IMethodSymbol methodSymbol, SemanticModel semanticModel, CancellationToken cancellationToken)
+	{
+		if (!methodSymbol.IsStatic || methodSymbol.Name != "Parse")
+			return null;
+
+		if (GetConversion(methodSymbol.ContainingType.SpecialType) is not { } conversion)
+			return null;
+
+		var arguments = invocation.ArgumentList.Arguments;
+		if (arguments.Count == 0 || !ParameterIsString(methodSymbol.Parameters[0]))
+			return null;
+
+		if (conversion.SpecialType == SpecialType.System_Boolean)
+		{
+			return methodSymbol.Parameters.Length == 1 ?
+				InvariantConvertMatch.CreateParse(invocation, conversion.ParseMethodName, arguments[0].Expression) :
+				null;
+		}
+
+		if (methodSymbol.Parameters.Length == 2)
+		{
+			if (IsInvariantCulture(arguments[1].Expression, semanticModel, cancellationToken))
+				return InvariantConvertMatch.CreateParse(invocation, conversion.ParseMethodName, arguments[0].Expression);
+		}
+		else if (methodSymbol.Parameters.Length == 3)
+		{
+			if (IsAllowedNumberStyle(arguments[1].Expression, conversion, semanticModel, cancellationToken) &&
+				IsInvariantCulture(arguments[2].Expression, semanticModel, cancellationToken))
+			{
+				return InvariantConvertMatch.CreateParse(invocation, conversion.ParseMethodName, arguments[0].Expression);
+			}
+		}
+
+		return null;
+	}
+
+	private static InvariantConvertMatch? TryCreateTryParseMatch(InvocationExpressionSyntax invocation, IMethodSymbol methodSymbol, SemanticModel semanticModel, CancellationToken cancellationToken)
+	{
+		if (!methodSymbol.IsStatic || methodSymbol.Name != "TryParse")
+			return null;
+
+		if (GetConversion(methodSymbol.ContainingType.SpecialType) is not { } conversion)
+			return null;
+
+		var arguments = invocation.ArgumentList.Arguments;
+		if (arguments.Count == 0 || !ParameterIsString(methodSymbol.Parameters[0]))
+			return null;
+
+		if (!TryGetOutVariable(arguments.Last(), out var outVariableIdentifier))
+			return null;
+
+		if (!TryGetSupportedTryParseCondition(invocation, out var isNegated, out var ifStatement))
+			return null;
+
+		if (!IsSafeTryParseScope(ifStatement, outVariableIdentifier, isNegated))
+			return null;
+
+		if (conversion.SpecialType == SpecialType.System_Boolean)
+		{
+			return methodSymbol.Parameters.Length == 2 ?
+				InvariantConvertMatch.CreateTryParse(invocation, conversion.TryParseMethodName, arguments[0].Expression, outVariableIdentifier, isNegated) :
+				null;
+		}
+
+		if (methodSymbol.Parameters.Length == 3)
+		{
+			if (IsInvariantCulture(arguments[1].Expression, semanticModel, cancellationToken))
+				return InvariantConvertMatch.CreateTryParse(invocation, conversion.TryParseMethodName, arguments[0].Expression, outVariableIdentifier, isNegated);
+		}
+		else if (methodSymbol.Parameters.Length == 4)
+		{
+			if (IsAllowedNumberStyle(arguments[1].Expression, conversion, semanticModel, cancellationToken) &&
+				IsInvariantCulture(arguments[2].Expression, semanticModel, cancellationToken))
+			{
+				return InvariantConvertMatch.CreateTryParse(invocation, conversion.TryParseMethodName, arguments[0].Expression, outVariableIdentifier, isNegated);
+			}
+		}
+
+		return null;
+	}
+
+	private static InvariantConvertMatch? TryCreateToStringMatch(InvocationExpressionSyntax invocation, IMethodSymbol methodSymbol, SemanticModel semanticModel, CancellationToken cancellationToken)
+	{
+		if (methodSymbol.IsStatic || methodSymbol.Name != "ToString" || methodSymbol.Parameters.Length != 1)
+			return null;
+
+		if (invocation.Expression is not MemberAccessExpressionSyntax memberAccessExpression)
+			return null;
+
+		if (GetConversion(semanticModel.GetTypeInfo(memberAccessExpression.Expression, cancellationToken).Type?.SpecialType ?? SpecialType.None) is null)
+			return null;
+
+		if (!IsInvariantCulture(invocation.ArgumentList.Arguments[0].Expression, semanticModel, cancellationToken))
+			return null;
+
+		return InvariantConvertMatch.CreateToString(invocation, memberAccessExpression.Expression);
+	}
+
+	private static bool ParameterIsString(IParameterSymbol parameter) =>
+		parameter.Type.SpecialType == SpecialType.System_String;
+
+	private static bool TryGetOutVariable(ArgumentSyntax argument, out SyntaxToken identifier)
+	{
+		identifier = default;
+
+		if (!argument.RefKindKeyword.IsKind(SyntaxKind.OutKeyword))
+			return false;
+
+		if (argument.Expression is not DeclarationExpressionSyntax { Designation: SingleVariableDesignationSyntax designation })
+			return false;
+
+		identifier = designation.Identifier;
+		return true;
+	}
+
+	private static bool TryGetSupportedTryParseCondition(InvocationExpressionSyntax invocation, out bool isNegated, out IfStatementSyntax ifStatement)
+	{
+		isNegated = false;
+		ifStatement = null!;
+
+		ExpressionSyntax conditionExpression = invocation;
+		if (conditionExpression.Parent is ParenthesizedExpressionSyntax parenthesizedExpression)
+			conditionExpression = parenthesizedExpression;
+
+		if (conditionExpression.Parent is PrefixUnaryExpressionSyntax { RawKind: (int) SyntaxKind.LogicalNotExpression } logicalNotExpression)
+		{
+			isNegated = true;
+			conditionExpression = logicalNotExpression;
+		}
+
+		if (conditionExpression.Parent is ParenthesizedExpressionSyntax parenthesizedCondition)
+			conditionExpression = parenthesizedCondition;
+
+		if (conditionExpression.Parent is IfStatementSyntax parentIfStatement && parentIfStatement.Condition == conditionExpression)
+		{
+			ifStatement = parentIfStatement;
+			return true;
+		}
+
+		return false;
+	}
+
+	private static bool IsSafeTryParseScope(IfStatementSyntax ifStatement, SyntaxToken outVariableIdentifier, bool isNegated)
+	{
+		if (ifStatement.Else is { } elseClause && ContainsIdentifierReference(elseClause.Statement, outVariableIdentifier))
+			return false;
+
+		if (ContainsIdentifierReference(ifStatement.Statement, outVariableIdentifier))
+			return !isNegated;
+
+		if (!ContainsReferenceAfterStatement(ifStatement, outVariableIdentifier))
+			return true;
+
+		return isNegated && StatementAlwaysExits(ifStatement.Statement);
+	}
+
+	private static bool ContainsReferenceAfterStatement(StatementSyntax statement, SyntaxToken identifier)
+	{
+		if (statement.Parent is not BlockSyntax block)
+			return false;
+
+		var foundStatement = false;
+		foreach (var childStatement in block.Statements)
+		{
+			if (foundStatement)
+			{
+				if (ContainsIdentifierReference(childStatement, identifier))
+					return true;
+			}
+			else if (childStatement == statement)
+			{
+				foundStatement = true;
+			}
+		}
+
+		return false;
+	}
+
+	private static bool ContainsIdentifierReference(SyntaxNode node, SyntaxToken identifier)
+	{
+		foreach (var identifierName in node.DescendantNodes().OfType<IdentifierNameSyntax>())
+		{
+			if (identifierName.Identifier.ValueText == identifier.ValueText)
+				return true;
+		}
+
+		return false;
+	}
+
+	private static bool StatementAlwaysExits(StatementSyntax statement)
+	{
+		if (statement is ReturnStatementSyntax || statement is ThrowStatementSyntax)
+			return true;
+
+		if (statement is BlockSyntax block && block.Statements.Count != 0)
+			return StatementAlwaysExits(block.Statements.Last());
+
+		return false;
+	}
+
+	private static bool IsInvariantCulture(ExpressionSyntax expression, SemanticModel semanticModel, CancellationToken cancellationToken) =>
+		semanticModel.Compilation.GetTypeByMetadataName("System.Globalization.CultureInfo") is { } cultureInfoType &&
+		semanticModel.GetSymbolInfo(expression, cancellationToken).Symbol is { Name: "InvariantCulture" } symbol &&
+		SymbolEqualityComparer.Default.Equals(symbol.ContainingType, cultureInfoType);
+
+	private static bool IsAllowedNumberStyle(ExpressionSyntax expression, InvariantConvertConversion conversion, SemanticModel semanticModel, CancellationToken cancellationToken) =>
+		semanticModel.Compilation.GetTypeByMetadataName("System.Globalization.NumberStyles") is { } numberStylesType &&
+		semanticModel.GetSymbolInfo(expression, cancellationToken).Symbol is { } symbol &&
+		SymbolEqualityComparer.Default.Equals(symbol.ContainingType, numberStylesType) &&
+		symbol.Name == conversion.NumberStyleName;
+
+	private static InvariantConvertConversion? GetConversion(SpecialType specialType) =>
+		specialType switch
+		{
+			SpecialType.System_Boolean => s_booleanConversion,
+			SpecialType.System_Double => s_doubleConversion,
+			SpecialType.System_Int32 => s_int32Conversion,
+			SpecialType.System_Int64 => s_int64Conversion,
+			_ => null,
+		};
+
+	private static bool HasMethod(INamedTypeSymbol type, string methodName)
+	{
+		foreach (var member in type.GetMembers(methodName))
+		{
+			if (member is IMethodSymbol { DeclaredAccessibility: Accessibility.Public, IsStatic: true })
+				return true;
+		}
+
+		return false;
 	}
 
 	public const string DiagnosticId = "FL0026";
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [s_rule];
+	private const string c_invariantConvertMetadataName = "Libronix.Utility.Invariant.InvariantConvert";
+
+	private static readonly InvariantConvertConversion s_booleanConversion = new(SpecialType.System_Boolean, "ParseBoolean", "TryParseBoolean", "");
+	private static readonly InvariantConvertConversion s_doubleConversion = new(SpecialType.System_Double, "ParseDouble", "TryParseDouble", "Float");
+	private static readonly InvariantConvertConversion s_int32Conversion = new(SpecialType.System_Int32, "ParseInt32", "TryParseInt32", "Integer");
+	private static readonly InvariantConvertConversion s_int64Conversion = new(SpecialType.System_Int64, "ParseInt64", "TryParseInt64", "Integer");
 
 	private static readonly DiagnosticDescriptor s_rule = new(
 		id: DiagnosticId,

--- a/src/Faithlife.Analyzers/InvariantConvertAnalyzer.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertAnalyzer.cs
@@ -69,24 +69,33 @@ public sealed class InvariantConvertAnalyzer : DiagnosticAnalyzer
 		if (arguments.Count == 0 || !ParameterIsString(methodSymbol.Parameters[0]))
 			return null;
 
+		var inputArgument = GetArgument(arguments, methodSymbol, 0);
+		if (inputArgument is null)
+			return null;
+
 		if (conversion.SpecialType == SpecialType.System_Boolean)
 		{
 			return methodSymbol.Parameters.Length == 1 ?
-				InvariantConvertMatch.CreateParse(invocation, conversion.ParseMethodName, arguments[0].Expression) :
+				InvariantConvertMatch.CreateParse(invocation, conversion.ParseMethodName, inputArgument.Expression) :
 				null;
 		}
 
 		if (methodSymbol.Parameters.Length == 2)
 		{
-			if (IsInvariantCulture(arguments[1].Expression, semanticModel, cancellationToken))
-				return InvariantConvertMatch.CreateParse(invocation, conversion.ParseMethodName, arguments[0].Expression);
+			if (GetArgument(arguments, methodSymbol, 1) is { } providerArgument &&
+				IsInvariantCulture(providerArgument.Expression, semanticModel, cancellationToken))
+			{
+				return InvariantConvertMatch.CreateParse(invocation, conversion.ParseMethodName, inputArgument.Expression);
+			}
 		}
 		else if (methodSymbol.Parameters.Length == 3)
 		{
-			if (IsAllowedNumberStyle(arguments[1].Expression, conversion, semanticModel, cancellationToken) &&
-				IsInvariantCulture(arguments[2].Expression, semanticModel, cancellationToken))
+			if (GetArgument(arguments, methodSymbol, 1) is { } styleArgument &&
+				GetArgument(arguments, methodSymbol, 2) is { } providerArgument &&
+				IsAllowedNumberStyle(styleArgument.Expression, conversion, semanticModel, cancellationToken) &&
+				IsInvariantCulture(providerArgument.Expression, semanticModel, cancellationToken))
 			{
-				return InvariantConvertMatch.CreateParse(invocation, conversion.ParseMethodName, arguments[0].Expression);
+				return InvariantConvertMatch.CreateParse(invocation, conversion.ParseMethodName, inputArgument.Expression);
 			}
 		}
 
@@ -105,37 +114,51 @@ public sealed class InvariantConvertAnalyzer : DiagnosticAnalyzer
 		if (arguments.Count == 0 || !ParameterIsString(methodSymbol.Parameters[0]))
 			return null;
 
-		if (!TryGetOutVariable(arguments.Last(), out var outVariableIdentifier))
-			return null;
-
-		if (!TryGetSupportedTryParseCondition(invocation, out var isNegated, out var ifStatement))
-			return null;
-
-		if (!IsSafeTryParseScope(ifStatement, outVariableIdentifier, isNegated))
+		var inputArgument = GetArgument(arguments, methodSymbol, 0);
+		var outputArgument = GetArgument(arguments, methodSymbol, methodSymbol.Parameters.Length - 1);
+		if (inputArgument is null || outputArgument is null)
 			return null;
 
 		if (conversion.SpecialType == SpecialType.System_Boolean)
 		{
-			return methodSymbol.Parameters.Length == 2 ?
-				InvariantConvertMatch.CreateTryParse(invocation, conversion.TryParseMethodName, arguments[0].Expression, outVariableIdentifier, isNegated) :
-				null;
+			if (methodSymbol.Parameters.Length != 2)
+				return null;
+
+			return CreateTryParseMatch(invocation, conversion.TryParseMethodName, inputArgument.Expression, outputArgument);
 		}
 
 		if (methodSymbol.Parameters.Length == 3)
 		{
-			if (IsInvariantCulture(arguments[1].Expression, semanticModel, cancellationToken))
-				return InvariantConvertMatch.CreateTryParse(invocation, conversion.TryParseMethodName, arguments[0].Expression, outVariableIdentifier, isNegated);
+			if (GetArgument(arguments, methodSymbol, 1) is { } providerArgument &&
+				IsInvariantCulture(providerArgument.Expression, semanticModel, cancellationToken))
+			{
+				return CreateTryParseMatch(invocation, conversion.TryParseMethodName, inputArgument.Expression, outputArgument);
+			}
 		}
 		else if (methodSymbol.Parameters.Length == 4)
 		{
-			if (IsAllowedNumberStyle(arguments[1].Expression, conversion, semanticModel, cancellationToken) &&
-				IsInvariantCulture(arguments[2].Expression, semanticModel, cancellationToken))
+			if (GetArgument(arguments, methodSymbol, 1) is { } styleArgument &&
+				GetArgument(arguments, methodSymbol, 2) is { } providerArgument &&
+				IsAllowedNumberStyle(styleArgument.Expression, conversion, semanticModel, cancellationToken) &&
+				IsInvariantCulture(providerArgument.Expression, semanticModel, cancellationToken))
 			{
-				return InvariantConvertMatch.CreateTryParse(invocation, conversion.TryParseMethodName, arguments[0].Expression, outVariableIdentifier, isNegated);
+				return CreateTryParseMatch(invocation, conversion.TryParseMethodName, inputArgument.Expression, outputArgument);
 			}
 		}
 
 		return null;
+	}
+
+	private static InvariantConvertMatch CreateTryParseMatch(InvocationExpressionSyntax invocation, string methodName, ExpressionSyntax inputExpression, ArgumentSyntax outputArgument)
+	{
+		if (TryGetOutVariable(outputArgument, out var outVariableIdentifier) &&
+			TryGetSupportedTryParseCondition(invocation, out var isNegated, out var ifStatement) &&
+			IsSafeTryParseScope(ifStatement, outVariableIdentifier, isNegated))
+		{
+			return InvariantConvertMatch.CreateTryParse(invocation, methodName, inputExpression, outVariableIdentifier, isNegated);
+		}
+
+		return InvariantConvertMatch.CreateUnfixableTryParse(invocation);
 	}
 
 	private static InvariantConvertMatch? TryCreateToStringMatch(InvocationExpressionSyntax invocation, IMethodSymbol methodSymbol, SemanticModel semanticModel, CancellationToken cancellationToken)
@@ -157,6 +180,26 @@ public sealed class InvariantConvertAnalyzer : DiagnosticAnalyzer
 
 	private static bool ParameterIsString(IParameterSymbol parameter) =>
 		parameter.Type.SpecialType == SpecialType.System_String;
+
+	private static ArgumentSyntax? GetArgument(SeparatedSyntaxList<ArgumentSyntax> arguments, IMethodSymbol methodSymbol, int parameterIndex)
+	{
+		var parameter = methodSymbol.Parameters[parameterIndex];
+		for (int i = 0; i < arguments.Count; i++)
+		{
+			var argument = arguments[i];
+			if (argument.NameColon is null)
+			{
+				if (i == parameterIndex)
+					return argument;
+			}
+			else if (argument.NameColon.Name.Identifier.ValueText == parameter.Name)
+			{
+				return argument;
+			}
+		}
+
+		return null;
+	}
 
 	private static bool TryGetOutVariable(ArgumentSyntax argument, out SyntaxToken identifier)
 	{
@@ -205,12 +248,17 @@ public sealed class InvariantConvertAnalyzer : DiagnosticAnalyzer
 			return false;
 
 		if (ContainsIdentifierReference(ifStatement.Statement, outVariableIdentifier))
-			return !isNegated;
+		{
+			if (isNegated)
+				return false;
+		}
 
 		if (!ContainsReferenceAfterStatement(ifStatement, outVariableIdentifier))
 			return true;
 
-		return isNegated && StatementAlwaysExits(ifStatement.Statement);
+		return isNegated ?
+			StatementAlwaysExits(ifStatement.Statement) :
+			ifStatement.Else is not null && StatementAlwaysExits(ifStatement.Else.Statement);
 	}
 
 	private static bool ContainsReferenceAfterStatement(StatementSyntax statement, SyntaxToken identifier)

--- a/src/Faithlife.Analyzers/InvariantConvertAnalyzer.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertAnalyzer.cs
@@ -1,0 +1,28 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Faithlife.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class InvariantConvertAnalyzer : DiagnosticAnalyzer
+{
+	public override void Initialize(AnalysisContext context)
+	{
+		context.EnableConcurrentExecution();
+		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+	}
+
+	public const string DiagnosticId = "FL0026";
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [s_rule];
+
+	private static readonly DiagnosticDescriptor s_rule = new(
+		id: DiagnosticId,
+		title: "Use InvariantConvert",
+		messageFormat: "Use InvariantConvert for invariant culture conversions",
+		category: "Usage",
+		defaultSeverity: DiagnosticSeverity.Info,
+		isEnabledByDefault: true,
+		helpLinkUri: $"https://github.com/Faithlife/FaithlifeAnalyzers/blob/-/docs/{DiagnosticId}.md");
+}

--- a/src/Faithlife.Analyzers/InvariantConvertCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertCodeFixProvider.cs
@@ -1,7 +1,13 @@
 using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Simplification;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Faithlife.Analyzers;
 
@@ -12,5 +18,114 @@ public sealed class InvariantConvertCodeFixProvider : CodeFixProvider
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
-	public sealed override Task RegisterCodeFixesAsync(CodeFixContext context) => Task.CompletedTask;
+	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+	{
+		var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+		if (root is null)
+			return;
+
+		var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+		if (semanticModel is null || !InvariantConvertAnalyzer.HasInvariantConvert(semanticModel.Compilation))
+			return;
+
+		var diagnostic = context.Diagnostics.First();
+		var diagnosticNode = root.FindNode(diagnostic.Location.SourceSpan);
+		var invocation = diagnosticNode.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+		if (invocation is null)
+			return;
+
+		var match = InvariantConvertAnalyzer.TryCreateMatch(invocation, semanticModel, context.CancellationToken);
+		if (match is null)
+			return;
+
+		context.RegisterCodeFix(
+			CodeAction.Create(
+				title: "Use InvariantConvert",
+				createChangedDocument: token => ReplaceValueAsync(context.Document, match, token),
+				"use-invariantconvert"),
+			diagnostic);
+	}
+
+	private static async Task<Document> ReplaceValueAsync(Document document, InvariantConvertMatch match, CancellationToken cancellationToken)
+	{
+		var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+		var replacement = CreateReplacement(match).WithTriviaFrom(match.Invocation).WithAdditionalAnnotations(Formatter.Annotation);
+		root = root.ReplaceNode(GetReplacementTarget(match), replacement);
+
+		if (root is CompilationUnitSyntax compilationUnit)
+			root = AddInvariantUsing(compilationUnit);
+
+		root = SimplifyUsing(root, s_systemGlobalizationNamespace);
+
+		return await Simplifier.ReduceAsync(
+			await Simplifier.ReduceAsync(document.WithSyntaxRoot(root), cancellationToken: cancellationToken).ConfigureAwait(false),
+			cancellationToken: cancellationToken).ConfigureAwait(false);
+	}
+
+	private static SyntaxNode GetReplacementTarget(InvariantConvertMatch match)
+	{
+		if (match.Kind == InvariantConvertMatchKind.TryParse &&
+			match.IsNegated &&
+			match.Invocation.Parent is PrefixUnaryExpressionSyntax { RawKind: (int) SyntaxKind.LogicalNotExpression } logicalNotExpression)
+		{
+			return logicalNotExpression;
+		}
+
+		return match.Invocation;
+	}
+
+	private static ExpressionSyntax CreateReplacement(InvariantConvertMatch match) =>
+		match.Kind switch
+		{
+			InvariantConvertMatchKind.Parse => CreateInvariantConvertInvocation(match.MethodName, match.InputExpression!),
+			InvariantConvertMatchKind.TryParse => CreateTryParseReplacement(match),
+			InvariantConvertMatchKind.ToString => InvocationExpression(
+				MemberAccessExpression(
+					SyntaxKind.SimpleMemberAccessExpression,
+					match.ReceiverExpression!,
+					IdentifierName("ToInvariantString"))),
+			_ => throw new InvalidOperationException("Unsupported InvariantConvert match."),
+		};
+
+	private static ExpressionSyntax CreateTryParseReplacement(InvariantConvertMatch match)
+	{
+		var replacement = CreateInvariantConvertInvocation(match.MethodName, match.InputExpression!);
+		var patternText = match.IsNegated ?
+			$"value is not {{ }} {match.OutVariableIdentifier.ValueText}" :
+			$"value is {{ }} {match.OutVariableIdentifier.ValueText}";
+
+		return SyntaxUtility.ReplaceIdentifier(ParseExpression(patternText), "value", replacement);
+	}
+
+	private static ExpressionSyntax CreateInvariantConvertInvocation(string methodName, ExpressionSyntax inputExpression) =>
+		SyntaxUtility.ReplaceIdentifier(
+			ParseExpression($"InvariantConvert.{methodName}(value)"),
+			"value",
+			inputExpression);
+
+	private static SyntaxNode SimplifyUsing(SyntaxNode root, NameSyntax namespaceName)
+	{
+		var usingDirective = root.DescendantNodes()
+			.OfType<UsingDirectiveSyntax>()
+			.FirstOrDefault(x => AreEquivalent(x.Name, namespaceName));
+
+		if (usingDirective is null)
+			return root;
+
+		return root.ReplaceNode(usingDirective, usingDirective.WithAdditionalAnnotations(Simplifier.Annotation));
+	}
+
+	private static CompilationUnitSyntax AddInvariantUsing(CompilationUnitSyntax root)
+	{
+		foreach (var usingDirective in root.Usings)
+		{
+			if (AreEquivalent(usingDirective.Name, s_invariantNamespace))
+				return root;
+		}
+
+		return root.WithUsings(root.Usings.Add(UsingDirective(s_invariantNamespace).WithTrailingTrivia(TriviaList(CarriageReturnLineFeed))));
+	}
+
+	private static readonly NameSyntax s_invariantNamespace = ParseName("Libronix.Utility.Invariant");
+	private static readonly NameSyntax s_systemGlobalizationNamespace = ParseName("System.Globalization");
 }

--- a/src/Faithlife.Analyzers/InvariantConvertCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertCodeFixProvider.cs
@@ -35,7 +35,7 @@ public sealed class InvariantConvertCodeFixProvider : CodeFixProvider
 			return;
 
 		var match = InvariantConvertAnalyzer.TryCreateMatch(invocation, semanticModel, context.CancellationToken);
-		if (match is null)
+		if (match is null || !match.CanFix)
 			return;
 
 		context.RegisterCodeFix(
@@ -55,7 +55,8 @@ public sealed class InvariantConvertCodeFixProvider : CodeFixProvider
 		if (root is CompilationUnitSyntax compilationUnit)
 			root = AddInvariantUsing(compilationUnit);
 
-		root = SimplifyUsing(root, s_systemGlobalizationNamespace);
+		foreach (var namespaceName in s_simplifiableNamespaces)
+			root = SimplifyUsing(root, namespaceName);
 
 		return await Simplifier.ReduceAsync(
 			await Simplifier.ReduceAsync(document.WithSyntaxRoot(root), cancellationToken: cancellationToken).ConfigureAwait(false),
@@ -64,9 +65,14 @@ public sealed class InvariantConvertCodeFixProvider : CodeFixProvider
 
 	private static SyntaxNode GetReplacementTarget(InvariantConvertMatch match)
 	{
-		if (match.Kind == InvariantConvertMatchKind.TryParse &&
-			match.IsNegated &&
-			match.Invocation.Parent is PrefixUnaryExpressionSyntax { RawKind: (int) SyntaxKind.LogicalNotExpression } logicalNotExpression)
+		if (match.Kind != InvariantConvertMatchKind.TryParse || !match.IsNegated)
+			return match.Invocation;
+
+		SyntaxNode currentNode = match.Invocation;
+		while (currentNode.Parent is ParenthesizedExpressionSyntax)
+			currentNode = currentNode.Parent;
+
+		if (currentNode.Parent is PrefixUnaryExpressionSyntax { RawKind: (int) SyntaxKind.LogicalNotExpression } logicalNotExpression)
 		{
 			return logicalNotExpression;
 		}
@@ -131,5 +137,14 @@ public sealed class InvariantConvertCodeFixProvider : CodeFixProvider
 	}
 
 	private static readonly NameSyntax s_invariantNamespace = ParseName("Libronix.Utility.Invariant");
-	private static readonly NameSyntax s_systemGlobalizationNamespace = ParseName("System.Globalization");
+	private static readonly NameSyntax[] s_simplifiableNamespaces =
+	[
+		ParseName("System.Globalization"),
+		ParseName("System.Globalization.CultureInfo"),
+		ParseName("System.Globalization.NumberStyles"),
+		ParseName("System.Boolean"),
+		ParseName("System.Double"),
+		ParseName("System.Int32"),
+		ParseName("System.Int64"),
+	];
 }

--- a/src/Faithlife.Analyzers/InvariantConvertCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertCodeFixProvider.cs
@@ -123,7 +123,11 @@ public sealed class InvariantConvertCodeFixProvider : CodeFixProvider
 				return root;
 		}
 
-		return root.WithUsings(root.Usings.Add(UsingDirective(s_invariantNamespace).WithTrailingTrivia(TriviaList(CarriageReturnLineFeed))));
+		var trailingTrivia = root.Usings.Count == 0 ?
+			TriviaList(ElasticCarriageReturnLineFeed) :
+			root.Usings.Last().GetTrailingTrivia();
+
+		return root.WithUsings(root.Usings.Add(UsingDirective(s_invariantNamespace).WithTrailingTrivia(trailingTrivia)));
 	}
 
 	private static readonly NameSyntax s_invariantNamespace = ParseName("Libronix.Utility.Invariant");

--- a/src/Faithlife.Analyzers/InvariantConvertCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertCodeFixProvider.cs
@@ -1,0 +1,16 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Faithlife.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(InvariantConvertCodeFixProvider)), Shared]
+public sealed class InvariantConvertCodeFixProvider : CodeFixProvider
+{
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => [InvariantConvertAnalyzer.DiagnosticId];
+
+	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+	public sealed override Task RegisterCodeFixesAsync(CodeFixContext context) => Task.CompletedTask;
+}

--- a/src/Faithlife.Analyzers/InvariantConvertConversion.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertConversion.cs
@@ -1,0 +1,22 @@
+using Microsoft.CodeAnalysis;
+
+namespace Faithlife.Analyzers;
+
+internal sealed class InvariantConvertConversion
+{
+	public InvariantConvertConversion(SpecialType specialType, string parseMethodName, string tryParseMethodName, string numberStyleName)
+	{
+		SpecialType = specialType;
+		ParseMethodName = parseMethodName;
+		TryParseMethodName = tryParseMethodName;
+		NumberStyleName = numberStyleName;
+	}
+
+	public SpecialType SpecialType { get; }
+
+	public string ParseMethodName { get; }
+
+	public string TryParseMethodName { get; }
+
+	public string NumberStyleName { get; }
+}

--- a/src/Faithlife.Analyzers/InvariantConvertMatch.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertMatch.cs
@@ -6,7 +6,7 @@ namespace Faithlife.Analyzers;
 internal sealed class InvariantConvertMatch
 {
 	private InvariantConvertMatch(InvariantConvertMatchKind kind, InvocationExpressionSyntax invocation, string methodName, ExpressionSyntax? inputExpression,
-		ExpressionSyntax? receiverExpression, SyntaxToken outVariableIdentifier, bool isNegated)
+		ExpressionSyntax? receiverExpression, SyntaxToken outVariableIdentifier, bool isNegated, bool canFix)
 	{
 		Kind = kind;
 		Invocation = invocation;
@@ -15,17 +15,21 @@ internal sealed class InvariantConvertMatch
 		ReceiverExpression = receiverExpression;
 		OutVariableIdentifier = outVariableIdentifier;
 		IsNegated = isNegated;
+		CanFix = canFix;
 	}
 
 	public static InvariantConvertMatch CreateParse(InvocationExpressionSyntax invocation, string methodName, ExpressionSyntax inputExpression) =>
-		new(InvariantConvertMatchKind.Parse, invocation, methodName, inputExpression, null, default, false);
+		new(InvariantConvertMatchKind.Parse, invocation, methodName, inputExpression, null, default, false, true);
 
 	public static InvariantConvertMatch CreateTryParse(InvocationExpressionSyntax invocation, string methodName, ExpressionSyntax inputExpression,
 		SyntaxToken outVariableIdentifier, bool isNegated) =>
-		new(InvariantConvertMatchKind.TryParse, invocation, methodName, inputExpression, null, outVariableIdentifier, isNegated);
+		new(InvariantConvertMatchKind.TryParse, invocation, methodName, inputExpression, null, outVariableIdentifier, isNegated, true);
+
+	public static InvariantConvertMatch CreateUnfixableTryParse(InvocationExpressionSyntax invocation) =>
+		new(InvariantConvertMatchKind.TryParse, invocation, "", null, null, default, false, false);
 
 	public static InvariantConvertMatch CreateToString(InvocationExpressionSyntax invocation, ExpressionSyntax receiverExpression) =>
-		new(InvariantConvertMatchKind.ToString, invocation, "ToInvariantString", null, receiverExpression, default, false);
+		new(InvariantConvertMatchKind.ToString, invocation, "ToInvariantString", null, receiverExpression, default, false, true);
 
 	public InvariantConvertMatchKind Kind { get; }
 
@@ -40,4 +44,6 @@ internal sealed class InvariantConvertMatch
 	public SyntaxToken OutVariableIdentifier { get; }
 
 	public bool IsNegated { get; }
+
+	public bool CanFix { get; }
 }

--- a/src/Faithlife.Analyzers/InvariantConvertMatch.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertMatch.cs
@@ -1,0 +1,43 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Faithlife.Analyzers;
+
+internal sealed class InvariantConvertMatch
+{
+	private InvariantConvertMatch(InvariantConvertMatchKind kind, InvocationExpressionSyntax invocation, string methodName, ExpressionSyntax? inputExpression,
+		ExpressionSyntax? receiverExpression, SyntaxToken outVariableIdentifier, bool isNegated)
+	{
+		Kind = kind;
+		Invocation = invocation;
+		MethodName = methodName;
+		InputExpression = inputExpression;
+		ReceiverExpression = receiverExpression;
+		OutVariableIdentifier = outVariableIdentifier;
+		IsNegated = isNegated;
+	}
+
+	public static InvariantConvertMatch CreateParse(InvocationExpressionSyntax invocation, string methodName, ExpressionSyntax inputExpression) =>
+		new(InvariantConvertMatchKind.Parse, invocation, methodName, inputExpression, null, default, false);
+
+	public static InvariantConvertMatch CreateTryParse(InvocationExpressionSyntax invocation, string methodName, ExpressionSyntax inputExpression,
+		SyntaxToken outVariableIdentifier, bool isNegated) =>
+		new(InvariantConvertMatchKind.TryParse, invocation, methodName, inputExpression, null, outVariableIdentifier, isNegated);
+
+	public static InvariantConvertMatch CreateToString(InvocationExpressionSyntax invocation, ExpressionSyntax receiverExpression) =>
+		new(InvariantConvertMatchKind.ToString, invocation, "ToInvariantString", null, receiverExpression, default, false);
+
+	public InvariantConvertMatchKind Kind { get; }
+
+	public InvocationExpressionSyntax Invocation { get; }
+
+	public string MethodName { get; }
+
+	public ExpressionSyntax? InputExpression { get; }
+
+	public ExpressionSyntax? ReceiverExpression { get; }
+
+	public SyntaxToken OutVariableIdentifier { get; }
+
+	public bool IsNegated { get; }
+}

--- a/src/Faithlife.Analyzers/InvariantConvertMatchKind.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertMatchKind.cs
@@ -1,0 +1,8 @@
+namespace Faithlife.Analyzers;
+
+internal enum InvariantConvertMatchKind
+{
+	Parse,
+	TryParse,
+	ToString,
+}

--- a/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
@@ -29,7 +29,7 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 	public void Parse(string invalidStatement, string fixedStatement, string diagnosticText)
 	{
 		var invalidProgram = CreateProgram(invalidStatement);
-		var fixedProgram = CreateProgram(fixedStatement, includeInvariantUsing: true);
+		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true);
 
 		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, diagnosticText));
 		VerifyCSharpFix(invalidProgram, fixedProgram);
@@ -51,7 +51,7 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 		var invalidStatement = $"if ({invalidCondition})\n\t\t\t\tGC.KeepAlive(value);";
 		var fixedStatement = $"if ({fixedCondition})\n\t\t\t\tGC.KeepAlive(value);";
 		var invalidProgram = CreateProgram(invalidStatement);
-		var fixedProgram = CreateProgram(fixedStatement, includeInvariantUsing: true);
+		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true);
 
 		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, invalidCondition));
 		VerifyCSharpFix(invalidProgram, fixedProgram);
@@ -66,7 +66,7 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 		var invalidStatement = $"if ({invalidCondition})\n\t\t\t\treturn;\n\t\t\tGC.KeepAlive(value);";
 		var fixedStatement = $"if ({fixedCondition})\n\t\t\t\treturn;\n\t\t\tGC.KeepAlive(value);";
 		var invalidProgram = CreateProgram(invalidStatement);
-		var fixedProgram = CreateProgram(fixedStatement, includeInvariantUsing: true);
+		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true);
 
 		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, diagnosticText));
 		VerifyCSharpFix(invalidProgram, fixedProgram);
@@ -81,7 +81,7 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 		var invalidStatement = $"var result = {invalidExpression};";
 		var fixedStatement = $"var result = {fixedExpression};";
 		var invalidProgram = CreateProgram(invalidStatement);
-		var fixedProgram = CreateProgram(fixedStatement, includeInvariantUsing: true);
+		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true);
 
 		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, invalidExpression));
 		VerifyCSharpFix(invalidProgram, fixedProgram);
@@ -168,11 +168,14 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 		};
 	}
 
-	private static string CreateProgram(string statement, bool includeInvariantConvert = true, bool includeInvariantUsing = false)
+	private static string CreateProgram(string statement, bool includeInvariantConvert = true, bool includeSystemGlobalization = true, bool includeInvariantUsing = false)
 	{
-		var usings = includeInvariantUsing ?
-			"using System;\nusing System.Globalization;\nusing Libronix.Utility.Invariant;" :
-			"using System;\nusing System.Globalization;";
+		var usings = "using System;";
+		if (includeSystemGlobalization)
+			usings += "\nusing System.Globalization;";
+		if (includeInvariantUsing)
+			usings += "\nusing Libronix.Utility.Invariant;";
+
 		var invariantConvert = includeInvariantConvert ? c_invariantConvert : "";
 
 		return $$"""

--- a/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
@@ -14,8 +14,11 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 	[TestCase("var result = int.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt32(input);", "int.Parse(input, CultureInfo.InvariantCulture)")]
 	[TestCase("var result = Int32.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt32(input);", "Int32.Parse(input, CultureInfo.InvariantCulture)")]
 	[TestCase("var result = System.Int32.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt32(input);", "System.Int32.Parse(input, CultureInfo.InvariantCulture)")]
+	[TestCase("var result = int.Parse(s: input, provider: CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt32(input);", "int.Parse(s: input, provider: CultureInfo.InvariantCulture)")]
+	[TestCase("var result = int.Parse(provider: CultureInfo.InvariantCulture, s: input);", "var result = InvariantConvert.ParseInt32(input);", "int.Parse(provider: CultureInfo.InvariantCulture, s: input)")]
 	[TestCase("var result = int.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt32(input);", "int.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture)")]
 	[TestCase("var result = Int32.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt32(input);", "Int32.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture)")]
+	[TestCase("var result = int.Parse(style: NumberStyles.Integer, provider: CultureInfo.InvariantCulture, s: input);", "var result = InvariantConvert.ParseInt32(input);", "int.Parse(style: NumberStyles.Integer, provider: CultureInfo.InvariantCulture, s: input)")]
 	[TestCase("var result = double.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseDouble(input);", "double.Parse(input, CultureInfo.InvariantCulture)")]
 	[TestCase("var result = Double.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseDouble(input);", "Double.Parse(input, CultureInfo.InvariantCulture)")]
 	[TestCase("var result = System.Double.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseDouble(input);", "System.Double.Parse(input, CultureInfo.InvariantCulture)")]
@@ -39,7 +42,9 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 	[TestCase("Boolean.TryParse(input, out bool value)", "InvariantConvert.TryParseBoolean(input) is { } value")]
 	[TestCase("int.TryParse(input, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseInt32(input) is { } value")]
 	[TestCase("Int32.TryParse(input, CultureInfo.InvariantCulture, out int value)", "InvariantConvert.TryParseInt32(input) is { } value")]
+	[TestCase("int.TryParse(result: out var value, provider: CultureInfo.InvariantCulture, s: input)", "InvariantConvert.TryParseInt32(input) is { } value")]
 	[TestCase("int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseInt32(input) is { } value")]
+	[TestCase("int.TryParse(result: out var value, provider: CultureInfo.InvariantCulture, style: NumberStyles.Integer, s: input)", "InvariantConvert.TryParseInt32(input) is { } value")]
 	[TestCase("double.TryParse(input, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseDouble(input) is { } value")]
 	[TestCase("Double.TryParse(input, CultureInfo.InvariantCulture, out double value)", "InvariantConvert.TryParseDouble(input) is { } value")]
 	[TestCase("double.TryParse(input, NumberStyles.Float, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseDouble(input) is { } value")]
@@ -61,6 +66,7 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 	[TestCase("!int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseInt32(input) is not { } value", "int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)")]
 	[TestCase("!double.TryParse(input, NumberStyles.Float, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseDouble(input) is not { } value", "double.TryParse(input, NumberStyles.Float, CultureInfo.InvariantCulture, out var value)")]
 	[TestCase("!long.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseInt64(input) is not { } value", "long.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)")]
+	[TestCase("!(int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))", "InvariantConvert.TryParseInt32(input) is not { } value", "int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)")]
 	public void NegatedTryParseCondition(string invalidCondition, string fixedCondition, string diagnosticText)
 	{
 		var invalidStatement = $"if ({invalidCondition})\n\t\t\t\treturn;\n\t\t\tGC.KeepAlive(value);";
@@ -90,9 +96,7 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 	[Test]
 	public void NoDiagnosticWithoutInvariantConvert()
 	{
-		var invalidProgram = CreateProgram("var result = int.Parse(input, CultureInfo.InvariantCulture);", includeInvariantConvert: false);
-
-		VerifyCSharpDiagnostic(invalidProgram);
+		VerifyCSharpDiagnostic(CreateProgram("var result = int.Parse(input, CultureInfo.InvariantCulture);", includeInvariantConvert: false));
 	}
 
 	[TestCase("var result = int.Parse(input, NumberStyles.None, CultureInfo.InvariantCulture);")]
@@ -102,6 +106,7 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 	[TestCase("var result = int.Parse(input);")]
 	[TestCase("var result = int.Parse(input, CultureInfo.CurrentCulture);")]
 	[TestCase("var result = decimal.Parse(input, CultureInfo.InvariantCulture);")]
+	[TestCase("var result = intValue.ToString(\"D\", CultureInfo.InvariantCulture);")]
 	[TestCase("var result = objectValue.ToString();")]
 	[TestCase("var result = DateTime.UtcNow.ToString(CultureInfo.InvariantCulture);")]
 	[TestCase("var result = nullableInt.ToString();")]
@@ -111,19 +116,21 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 	}
 
 	[Test]
-	public void DoesNotDiagnoseTryParseExistingOutVariable()
+	public void TryParseExistingOutVariableIsDiagnosedButNotFixed()
 	{
 		const string statement = """
 			int value;
 			if (int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
 				GC.KeepAlive(value);
 			""";
+		var invalidProgram = CreateProgram(statement);
 
-		VerifyCSharpDiagnostic(CreateProgram(statement));
+		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, "int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out value)"));
+		VerifyCSharpFix(invalidProgram, invalidProgram);
 	}
 
 	[Test]
-	public void DoesNotDiagnoseTryParseOutVariableUsedAfterCondition()
+	public void TryParseOutVariableUsedAfterConditionIsDiagnosedButNotFixed()
 	{
 		const string statement = """
 			if (int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
@@ -131,13 +138,172 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 			}
 			GC.KeepAlive(value);
 			""";
+		var invalidProgram = CreateProgram(statement);
 
-		VerifyCSharpDiagnostic(CreateProgram(statement));
+		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, "int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)"));
+		VerifyCSharpFix(invalidProgram, invalidProgram);
+	}
+
+	[Test]
+	public void TryParseOutVariableUsedInBodyAndAfterConditionIsDiagnosedButNotFixed()
+	{
+		const string statement = """
+			if (int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+				GC.KeepAlive(value);
+			GC.KeepAlive(value);
+			""";
+
+		VerifyDiagnosticWithoutFix(statement, "int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)");
+	}
+
+	[Test]
+	public void TryParseOutVariableUsedAfterElseReturnIsFixed()
+	{
+		const string invalidStatement = """
+			if (int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+			{
+			}
+			else
+			{
+				return;
+			}
+			GC.KeepAlive(value);
+			""";
+		const string fixedStatement = """
+			if (InvariantConvert.TryParseInt32(input) is { } value)
+			{
+			}
+			else
+			{
+				return;
+			}
+			GC.KeepAlive(value);
+			""";
+		var invalidProgram = CreateProgram(invalidStatement);
+		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true);
+
+		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, "int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)"));
+		VerifyCSharpFix(invalidProgram, fixedProgram);
+	}
+
+	[Test]
+	public void TryParseDiscardIsDiagnosedButNotFixed()
+	{
+		const string statement = """
+			if (int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+				return;
+			""";
+
+		VerifyDiagnosticWithoutFix(statement, "int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out _)");
+	}
+
+	[Test]
+	public void TryParseStatementIsDiagnosedButNotFixed()
+	{
+		const string statement = "int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value);";
+
+		VerifyDiagnosticWithoutFix(statement, "int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)");
+	}
+
+	[Test]
+	public void TryParseAndConditionIsDiagnosedButNotFixed()
+	{
+		const string statement = """
+			if (boolValue && int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+				GC.KeepAlive(value);
+			""";
+
+		VerifyDiagnosticWithoutFix(statement, "int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)");
+	}
+
+	[Test]
+	public void TryParseOrConditionIsDiagnosedButNotFixed()
+	{
+		const string statement = """
+			if (int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) || boolValue)
+				GC.KeepAlive(value);
+			""";
+
+		VerifyDiagnosticWithoutFix(statement, "int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)");
+	}
+
+	[Test]
+	public void StaticAndAliasUsingsAreRemovedByFix()
+	{
+		const string invalidStatement = """
+			if (TryParse(input, NS.Integer, CI.InvariantCulture, out var value))
+				GC.KeepAlive(value);
+			""";
+		const string fixedStatement = """
+			if (InvariantConvert.TryParseInt32(input) is { } value)
+				GC.KeepAlive(value);
+			""";
+		var invalidProgram = CreateProgram(
+			invalidStatement,
+			includeSystemGlobalization: false,
+			extraUsings: "using CI = System.Globalization.CultureInfo;\nusing NS = System.Globalization.NumberStyles;\nusing static System.Int32;");
+		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true);
+
+		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, "TryParse(input, NS.Integer, CI.InvariantCulture, out var value)"));
+		VerifyCSharpFix(invalidProgram, fixedProgram);
+	}
+
+	[Test]
+	public void StaticCultureAndNumberStylesUsingsAreRemovedByFix()
+	{
+		const string invalidStatement = """
+			if (int.TryParse(input, Integer, InvariantCulture, out var value))
+				GC.KeepAlive(value);
+			""";
+		const string fixedStatement = """
+			if (InvariantConvert.TryParseInt32(input) is { } value)
+				GC.KeepAlive(value);
+			""";
+		var invalidProgram = CreateProgram(
+			invalidStatement,
+			includeSystemGlobalization: false,
+			extraUsings: "using static System.Globalization.CultureInfo;\nusing static System.Globalization.NumberStyles;");
+		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true);
+
+		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, "int.TryParse(input, Integer, InvariantCulture, out var value)"));
+		VerifyCSharpFix(invalidProgram, fixedProgram);
+	}
+
+	[Test]
+	public void TypeAliasUsingIsRemovedByFix()
+	{
+		const string invalidStatement = "var result = Integer.Parse(input, CultureInfo.InvariantCulture);";
+		const string fixedStatement = "var result = InvariantConvert.ParseInt32(input);";
+		var invalidProgram = CreateProgram(invalidStatement, extraUsings: "using Integer = System.Int32;");
+		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true);
+
+		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, "Integer.Parse(input, CultureInfo.InvariantCulture)"));
+		VerifyCSharpFix(invalidProgram, fixedProgram);
+	}
+
+	[Test]
+	public void ExistingInvariantUsingIsNotDuplicated()
+	{
+		const string invalidStatement = "var result = int.Parse(input, CultureInfo.InvariantCulture);";
+		const string fixedStatement = "var result = InvariantConvert.ParseInt32(input);";
+		var invalidProgram = CreateProgram(invalidStatement, includeInvariantUsing: true);
+		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true);
+
+		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, "int.Parse(input, CultureInfo.InvariantCulture)"));
+		VerifyCSharpFix(invalidProgram, fixedProgram);
 	}
 
 	protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new InvariantConvertAnalyzer();
 
 	protected override CodeFixProvider GetCSharpCodeFixProvider() => new InvariantConvertCodeFixProvider();
+
+	private void VerifyDiagnosticWithoutFix(string statement, string diagnosticText)
+	{
+		var invalidProgram = CreateProgram(statement);
+
+		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, diagnosticText));
+		VerifyCSharpFix(invalidProgram, invalidProgram);
+	}
 
 	private static DiagnosticResult CreateDiagnostic(string program, string diagnosticText)
 	{
@@ -168,13 +334,16 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 		};
 	}
 
-	private static string CreateProgram(string statement, bool includeInvariantConvert = true, bool includeSystemGlobalization = true, bool includeInvariantUsing = false)
+	private static string CreateProgram(string statement, bool includeInvariantConvert = true, bool includeSystemGlobalization = true,
+		bool includeInvariantUsing = false, string extraUsings = "")
 	{
 		var usings = "using System;";
 		if (includeSystemGlobalization)
 			usings += "\nusing System.Globalization;";
 		if (includeInvariantUsing)
 			usings += "\nusing Libronix.Utility.Invariant;";
+		if (extraUsings.Length != 0)
+			usings += "\n" + extraUsings;
 
 		var invariantConvert = includeInvariantConvert ? c_invariantConvert : "";
 

--- a/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
@@ -1,0 +1,216 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Framework;
+
+namespace Faithlife.Analyzers.Tests;
+
+[TestFixture]
+internal sealed class InvariantConvertTests : CodeFixVerifier
+{
+	[TestCase("var result = bool.Parse(input);", "var result = InvariantConvert.ParseBoolean(input);", "bool.Parse(input)")]
+	[TestCase("var result = Boolean.Parse(input);", "var result = InvariantConvert.ParseBoolean(input);", "Boolean.Parse(input)")]
+	[TestCase("var result = System.Boolean.Parse(input);", "var result = InvariantConvert.ParseBoolean(input);", "System.Boolean.Parse(input)")]
+	[TestCase("var result = int.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt32(input);", "int.Parse(input, CultureInfo.InvariantCulture)")]
+	[TestCase("var result = Int32.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt32(input);", "Int32.Parse(input, CultureInfo.InvariantCulture)")]
+	[TestCase("var result = System.Int32.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt32(input);", "System.Int32.Parse(input, CultureInfo.InvariantCulture)")]
+	[TestCase("var result = int.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt32(input);", "int.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture)")]
+	[TestCase("var result = Int32.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt32(input);", "Int32.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture)")]
+	[TestCase("var result = double.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseDouble(input);", "double.Parse(input, CultureInfo.InvariantCulture)")]
+	[TestCase("var result = Double.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseDouble(input);", "Double.Parse(input, CultureInfo.InvariantCulture)")]
+	[TestCase("var result = System.Double.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseDouble(input);", "System.Double.Parse(input, CultureInfo.InvariantCulture)")]
+	[TestCase("var result = double.Parse(input, NumberStyles.Float, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseDouble(input);", "double.Parse(input, NumberStyles.Float, CultureInfo.InvariantCulture)")]
+	[TestCase("var result = Double.Parse(input, NumberStyles.Float, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseDouble(input);", "Double.Parse(input, NumberStyles.Float, CultureInfo.InvariantCulture)")]
+	[TestCase("var result = long.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt64(input);", "long.Parse(input, CultureInfo.InvariantCulture)")]
+	[TestCase("var result = Int64.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt64(input);", "Int64.Parse(input, CultureInfo.InvariantCulture)")]
+	[TestCase("var result = System.Int64.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt64(input);", "System.Int64.Parse(input, CultureInfo.InvariantCulture)")]
+	[TestCase("var result = long.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt64(input);", "long.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture)")]
+	[TestCase("var result = Int64.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt64(input);", "Int64.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture)")]
+	public void Parse(string invalidStatement, string fixedStatement, string diagnosticText)
+	{
+		var invalidProgram = CreateProgram(invalidStatement);
+		var fixedProgram = CreateProgram(fixedStatement, includeInvariantUsing: true);
+
+		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, diagnosticText));
+		VerifyCSharpFix(invalidProgram, fixedProgram);
+	}
+
+	[TestCase("bool.TryParse(input, out var value)", "InvariantConvert.TryParseBoolean(input) is { } value")]
+	[TestCase("Boolean.TryParse(input, out bool value)", "InvariantConvert.TryParseBoolean(input) is { } value")]
+	[TestCase("int.TryParse(input, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseInt32(input) is { } value")]
+	[TestCase("Int32.TryParse(input, CultureInfo.InvariantCulture, out int value)", "InvariantConvert.TryParseInt32(input) is { } value")]
+	[TestCase("int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseInt32(input) is { } value")]
+	[TestCase("double.TryParse(input, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseDouble(input) is { } value")]
+	[TestCase("Double.TryParse(input, CultureInfo.InvariantCulture, out double value)", "InvariantConvert.TryParseDouble(input) is { } value")]
+	[TestCase("double.TryParse(input, NumberStyles.Float, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseDouble(input) is { } value")]
+	[TestCase("long.TryParse(input, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseInt64(input) is { } value")]
+	[TestCase("Int64.TryParse(input, CultureInfo.InvariantCulture, out long value)", "InvariantConvert.TryParseInt64(input) is { } value")]
+	[TestCase("long.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseInt64(input) is { } value")]
+	public void TryParseCondition(string invalidCondition, string fixedCondition)
+	{
+		var invalidStatement = $"if ({invalidCondition})\n\t\t\t\tGC.KeepAlive(value);";
+		var fixedStatement = $"if ({fixedCondition})\n\t\t\t\tGC.KeepAlive(value);";
+		var invalidProgram = CreateProgram(invalidStatement);
+		var fixedProgram = CreateProgram(fixedStatement, includeInvariantUsing: true);
+
+		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, invalidCondition));
+		VerifyCSharpFix(invalidProgram, fixedProgram);
+	}
+
+	[TestCase("!bool.TryParse(input, out var value)", "InvariantConvert.TryParseBoolean(input) is not { } value", "bool.TryParse(input, out var value)")]
+	[TestCase("!int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseInt32(input) is not { } value", "int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)")]
+	[TestCase("!double.TryParse(input, NumberStyles.Float, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseDouble(input) is not { } value", "double.TryParse(input, NumberStyles.Float, CultureInfo.InvariantCulture, out var value)")]
+	[TestCase("!long.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseInt64(input) is not { } value", "long.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)")]
+	public void NegatedTryParseCondition(string invalidCondition, string fixedCondition, string diagnosticText)
+	{
+		var invalidStatement = $"if ({invalidCondition})\n\t\t\t\treturn;\n\t\t\tGC.KeepAlive(value);";
+		var fixedStatement = $"if ({fixedCondition})\n\t\t\t\treturn;\n\t\t\tGC.KeepAlive(value);";
+		var invalidProgram = CreateProgram(invalidStatement);
+		var fixedProgram = CreateProgram(fixedStatement, includeInvariantUsing: true);
+
+		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, diagnosticText));
+		VerifyCSharpFix(invalidProgram, fixedProgram);
+	}
+
+	[TestCase("boolValue", "boolValue.ToString(CultureInfo.InvariantCulture)", "boolValue.ToInvariantString()")]
+	[TestCase("intValue", "intValue.ToString(CultureInfo.InvariantCulture)", "intValue.ToInvariantString()")]
+	[TestCase("doubleValue", "doubleValue.ToString(CultureInfo.InvariantCulture)", "doubleValue.ToInvariantString()")]
+	[TestCase("longValue", "longValue.ToString(CultureInfo.InvariantCulture)", "longValue.ToInvariantString()")]
+	public void ToStringInvariantCulture(string valueExpression, string invalidExpression, string fixedExpression)
+	{
+		var invalidStatement = $"var result = {invalidExpression};";
+		var fixedStatement = $"var result = {fixedExpression};";
+		var invalidProgram = CreateProgram(invalidStatement);
+		var fixedProgram = CreateProgram(fixedStatement, includeInvariantUsing: true);
+
+		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, invalidExpression));
+		VerifyCSharpFix(invalidProgram, fixedProgram);
+	}
+
+	[Test]
+	public void NoDiagnosticWithoutInvariantConvert()
+	{
+		var invalidProgram = CreateProgram("var result = int.Parse(input, CultureInfo.InvariantCulture);", includeInvariantConvert: false);
+
+		VerifyCSharpDiagnostic(invalidProgram);
+	}
+
+	[TestCase("var result = int.Parse(input, NumberStyles.None, CultureInfo.InvariantCulture);")]
+	[TestCase("var result = long.Parse(input, NumberStyles.None, CultureInfo.InvariantCulture);")]
+	[TestCase("var result = double.Parse(input, NumberStyles.None, CultureInfo.InvariantCulture);")]
+	[TestCase("var result = int.Parse(input, NumberStyles.HexNumber, CultureInfo.InvariantCulture);")]
+	[TestCase("var result = int.Parse(input);")]
+	[TestCase("var result = int.Parse(input, CultureInfo.CurrentCulture);")]
+	[TestCase("var result = decimal.Parse(input, CultureInfo.InvariantCulture);")]
+	[TestCase("var result = objectValue.ToString();")]
+	[TestCase("var result = DateTime.UtcNow.ToString(CultureInfo.InvariantCulture);")]
+	[TestCase("var result = nullableInt.ToString();")]
+	public void UnsupportedUsage(string statement)
+	{
+		VerifyCSharpDiagnostic(CreateProgram(statement));
+	}
+
+	[Test]
+	public void DoesNotDiagnoseTryParseExistingOutVariable()
+	{
+		const string statement = """
+			int value;
+			if (int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+				GC.KeepAlive(value);
+			""";
+
+		VerifyCSharpDiagnostic(CreateProgram(statement));
+	}
+
+	[Test]
+	public void DoesNotDiagnoseTryParseOutVariableUsedAfterCondition()
+	{
+		const string statement = """
+			if (int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+			{
+			}
+			GC.KeepAlive(value);
+			""";
+
+		VerifyCSharpDiagnostic(CreateProgram(statement));
+	}
+
+	protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new InvariantConvertAnalyzer();
+
+	protected override CodeFixProvider GetCSharpCodeFixProvider() => new InvariantConvertCodeFixProvider();
+
+	private static DiagnosticResult CreateDiagnostic(string program, string diagnosticText)
+	{
+		var index = program.IndexOf(diagnosticText, System.StringComparison.Ordinal);
+		Assert.That(index, Is.GreaterThanOrEqualTo(0), $"Could not find '{diagnosticText}' in the test program.");
+
+		var line = 1;
+		var column = 1;
+		for (int i = 0; i < index; i++)
+		{
+			if (program[i] == '\n')
+			{
+				line++;
+				column = 1;
+			}
+			else
+			{
+				column++;
+			}
+		}
+
+		return new DiagnosticResult
+		{
+			Id = InvariantConvertAnalyzer.DiagnosticId,
+			Message = "Use InvariantConvert for invariant culture conversions",
+			Severity = DiagnosticSeverity.Info,
+			Locations = [new DiagnosticResultLocation("Test0.cs", line, column)],
+		};
+	}
+
+	private static string CreateProgram(string statement, bool includeInvariantConvert = true, bool includeInvariantUsing = false)
+	{
+		var usings = includeInvariantUsing ?
+			"using System;\nusing System.Globalization;\nusing Libronix.Utility.Invariant;" :
+			"using System;\nusing System.Globalization;";
+		var invariantConvert = includeInvariantConvert ? c_invariantConvert : "";
+
+		return $$"""
+			{{usings}}
+
+			{{invariantConvert}}
+			namespace TestApplication
+			{
+				internal static class TestClass
+				{
+					public static void Test(string input, bool boolValue, int intValue, double doubleValue, long longValue, object objectValue, int? nullableInt)
+					{
+						{{statement}}
+					}
+				}
+			}
+			""";
+	}
+
+	private const string c_invariantConvert = """
+		namespace Libronix.Utility.Invariant
+		{
+			public static class InvariantConvert
+			{
+				public static string ToInvariantString(this bool value) => throw new NotImplementedException();
+				public static bool? TryParseBoolean(string text) => throw new NotImplementedException();
+				public static bool ParseBoolean(string text) => throw new NotImplementedException();
+				public static string ToInvariantString(this double value) => throw new NotImplementedException();
+				public static double? TryParseDouble(string text) => throw new NotImplementedException();
+				public static double ParseDouble(string text) => throw new NotImplementedException();
+				public static string ToInvariantString(this int value) => throw new NotImplementedException();
+				public static int? TryParseInt32(string text) => throw new NotImplementedException();
+				public static int ParseInt32(string text) => throw new NotImplementedException();
+				public static string ToInvariantString(this long value) => throw new NotImplementedException();
+				public static long? TryParseInt64(string text) => throw new NotImplementedException();
+				public static long ParseInt64(string text) => throw new NotImplementedException();
+			}
+		}
+
+		""";
+}


### PR DESCRIPTION
Libronix.Utility.Invariant.InvariantConvert is the standard helper for invariant parse and format operations, but existing code can still use direct `CultureInfo.InvariantCulture` parse and `ToString` overloads. This PR adds FL0026 so projects that already reference Libronix.Utility get a targeted diagnostic and code fix.

## Summary

- Adds an analyzer gated on `Libronix.Utility.Invariant.InvariantConvert` so projects without that dependency are not flagged.
- Rewrites supported `Parse`, `TryParse`, and `ToString(CultureInfo.InvariantCulture)` patterns for `bool`, `int`, `double`, and `long`.
- Leaves `NumberStyles.None` out of scope because replacing it with `InvariantConvert` would broaden accepted input.
- Adds analyzer tests plus FL0026 documentation and the README index entry.

## Testing

- `./build.ps1 test`