### PR TITLE
Add FL0026: Use InvariantConvert

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.6.2</VersionPrefix>
+    <VersionPrefix>1.7.0</VersionPrefix>
     <NoWarn>$(NoWarn);1591;1998;NU5105;CA1014;CA1508;CA1859;NU1507</NoWarn>
     <GitHubOrganization>Faithlife</GitHubOrganization>
     <RepositoryName>FaithlifeAnalyzers</RepositoryName>

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ dotnet_diagnostic.FL0009.severity = none
 | [FL0021](docs/FL0021.md) | Use null propagation |
 | [FL0022](docs/FL0022.md) | Use AsyncMethodContext.WorkState |
 | [FL0023](docs/FL0023.md) | Replace obsolete Logos.Common.Logging.Extensions extension methods |
+| [FL0026](docs/FL0026.md) | Use InvariantConvert |
 
 ## How to Help
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 1.7.0
+
+* Add [FL0026](https://github.com/Faithlife/FaithlifeAnalyzers/wiki/FL0026): Use `InvariantConvert`.
+
 ## 1.6.2
 
 * Move analyzer documentation from wiki to repository content.

--- a/docs/FL0026.md
+++ b/docs/FL0026.md
@@ -1,0 +1,78 @@
+# FL0026: Use InvariantConvert
+
+## Summary
+
+Detects culture-aware parsing and `ToString` calls that use `CultureInfo.InvariantCulture`
+and suggests the equivalent `Libronix.Utility.Invariant.InvariantConvert` helper.
+
+This analyzer only fires when the compilation references
+`Libronix.Utility.Invariant.InvariantConvert`. If that type is not available, no
+diagnostics are produced.
+
+## Replacements
+
+Applies to `bool`/`Boolean`, `int`/`Int32`, `long`/`Int64`, and `double`/`Double`.
+
+### Parse
+
+* `int.Parse(s, CultureInfo.InvariantCulture)` → `InvariantConvert.ParseInt32(s)`
+* `int.Parse(s, NumberStyles.None, CultureInfo.InvariantCulture)` → `InvariantConvert.ParseInt32(s)`
+* `int.Parse(s, NumberStyles.Integer, CultureInfo.InvariantCulture)` → `InvariantConvert.ParseInt32(s)`
+* `double.Parse(s, NumberStyles.Float, CultureInfo.InvariantCulture)` → `InvariantConvert.ParseDouble(s)`
+* `bool.Parse(s)` → `InvariantConvert.ParseBoolean(s)`
+
+### TryParse
+
+* `int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var x)` → `InvariantConvert.TryParseInt32(s) is { } x`
+
+### ToString
+
+* `value.ToString(CultureInfo.InvariantCulture)` → `value.ToInvariantString()`
+
+## Example
+
+### Before
+
+```csharp
+startIndex = int.Parse(splitRange[0], CultureInfo.InvariantCulture);
+
+if (!int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var hours))
+    return false;
+
+var str = x.ToString(CultureInfo.InvariantCulture);
+```
+
+### After
+
+```csharp
+startIndex = InvariantConvert.ParseInt32(splitRange[0]);
+
+if (InvariantConvert.TryParseInt32(parts[0]) is not { } hours)
+    return false;
+
+var str = x.ToInvariantString();
+```
+
+## Rationale
+
+`InvariantConvert` provides culture-invariant parsing and formatting helpers that are
+shorter, harder to misuse, and consistent across the codebase. Using them avoids
+repeating `CultureInfo.InvariantCulture` (and the associated `using System.Globalization;`)
+at every call site.
+
+## Notes
+
+* `TryParse` is only fixed automatically when the call is the entire condition of an `if`
+  (optionally negated with a single `!`) and the rewritten pattern variable remains
+  definitely assigned. In other contexts the diagnostic is reported but no automatic fix
+  is offered.
+* `NumberStyles.None` is matched even though `InvariantConvert` parses with
+  `NumberStyles.Integer`/`Float`, so the set of accepted inputs may differ slightly.
+* `double.Parse(s, CultureInfo.InvariantCulture)` accepts thousands separators, while
+  `InvariantConvert.ParseDouble` does not.
+* `bool.ToString(CultureInfo.InvariantCulture)` produces `"True"`/`"False"`, while
+  `ToInvariantString()` produces `"true"`/`"false"`.
+
+## Severity
+
+**Info** - Suggests using `InvariantConvert` helpers.

--- a/src/Faithlife.Analyzers/InvariantConvertContext.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertContext.cs
@@ -1,0 +1,176 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Faithlife.Analyzers;
+
+internal sealed class InvariantConvertContext
+{
+	public static InvariantConvertContext? TryCreate(Compilation compilation)
+	{
+		if (compilation.GetTypeByMetadataName("Libronix.Utility.Invariant.InvariantConvert") is null)
+			return null;
+		if (compilation.GetTypeByMetadataName("System.Globalization.CultureInfo") is not { } cultureInfoType)
+			return null;
+		if (compilation.GetTypeByMetadataName("System.Globalization.NumberStyles") is not { } numberStylesType)
+			return null;
+		if (compilation.GetTypeByMetadataName("System.IFormatProvider") is not { } formatProviderType)
+			return null;
+
+		return new InvariantConvertContext(cultureInfoType, numberStylesType, formatProviderType);
+	}
+
+	public InvariantConvertMatch? Match(InvocationExpressionSyntax invocation, SemanticModel semanticModel, CancellationToken cancellationToken = default)
+	{
+		if (semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol method)
+			return null;
+
+		var typeName = GetSupportedTypeName(method.ContainingType);
+		if (typeName is null)
+			return null;
+
+		return method.Name switch
+		{
+			"Parse" => MatchParse(invocation, method, typeName, semanticModel),
+			"TryParse" => MatchTryParse(invocation, method, typeName, semanticModel),
+			"ToString" => MatchToString(invocation, method, semanticModel),
+			_ => null,
+		};
+	}
+
+	private InvariantConvertMatch? MatchParse(InvocationExpressionSyntax invocation, IMethodSymbol method, string typeName, SemanticModel semanticModel)
+	{
+		if (!method.IsStatic)
+			return null;
+		if (!TryGetArguments(method, invocation.ArgumentList.Arguments, out var value, out var provider, out var style, out var outArgument))
+			return null;
+		if (value is null || outArgument is not null)
+			return null;
+
+		if (method.ContainingType.SpecialType == SpecialType.System_Boolean)
+		{
+			// bool.Parse has no culture-aware overload; only the single string argument is supported.
+			if (provider is not null || style is not null)
+				return null;
+		}
+		else
+		{
+			if (!IsInvariantCulture(provider, semanticModel) || !IsAllowedStyle(style, typeName, semanticModel))
+				return null;
+		}
+
+		return new InvariantConvertMatch(InvariantConvertKind.Parse, "Parse" + typeName, value.Expression, null);
+	}
+
+	private InvariantConvertMatch? MatchTryParse(InvocationExpressionSyntax invocation, IMethodSymbol method, string typeName, SemanticModel semanticModel)
+	{
+		if (!method.IsStatic)
+			return null;
+		if (!TryGetArguments(method, invocation.ArgumentList.Arguments, out var value, out var provider, out var style, out var outArgument))
+			return null;
+		if (value is null || outArgument is null)
+			return null;
+
+		if (method.ContainingType.SpecialType == SpecialType.System_Boolean)
+		{
+			if (provider is not null || style is not null)
+				return null;
+		}
+		else
+		{
+			if (!IsInvariantCulture(provider, semanticModel) || !IsAllowedStyle(style, typeName, semanticModel))
+				return null;
+		}
+
+		return new InvariantConvertMatch(InvariantConvertKind.TryParse, "TryParse" + typeName, value.Expression, outArgument);
+	}
+
+	private InvariantConvertMatch? MatchToString(InvocationExpressionSyntax invocation, IMethodSymbol method, SemanticModel semanticModel)
+	{
+		if (method.IsStatic)
+			return null;
+		if (method.Parameters.Length != 1 || !SymbolEqualityComparer.Default.Equals(method.Parameters[0].Type, m_formatProviderType))
+			return null;
+
+		var arguments = invocation.ArgumentList.Arguments;
+		if (arguments.Count != 1 || arguments[0].NameColon is not null)
+			return null;
+		if (!IsInvariantCulture(arguments[0], semanticModel))
+			return null;
+		if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+			return null;
+
+		return new InvariantConvertMatch(InvariantConvertKind.ToString, "ToInvariantString", memberAccess.Expression, null);
+	}
+
+	private bool TryGetArguments(IMethodSymbol method, SeparatedSyntaxList<ArgumentSyntax> arguments, out ArgumentSyntax? value, out ArgumentSyntax? provider, out ArgumentSyntax? style, out ArgumentSyntax? outArgument)
+	{
+		value = null;
+		provider = null;
+		style = null;
+		outArgument = null;
+
+		if (arguments.Any(x => x.NameColon is not null))
+			return false;
+		if (arguments.Count != method.Parameters.Length)
+			return false;
+
+		foreach (var parameter in method.Parameters)
+		{
+			var argument = arguments[parameter.Ordinal];
+			if (parameter.RefKind == RefKind.Out)
+				outArgument = argument;
+			else if (parameter.Type.SpecialType == SpecialType.System_String)
+				value = argument;
+			else if (SymbolEqualityComparer.Default.Equals(parameter.Type, m_numberStylesType))
+				style = argument;
+			else if (SymbolEqualityComparer.Default.Equals(parameter.Type, m_formatProviderType))
+				provider = argument;
+			else
+				return false;
+		}
+
+		return true;
+	}
+
+	private bool IsInvariantCulture(ArgumentSyntax? argument, SemanticModel semanticModel)
+	{
+		if (argument is null)
+			return false;
+
+		return semanticModel.GetSymbolInfo(argument.Expression).Symbol is IPropertySymbol property &&
+			property.Name == "InvariantCulture" &&
+			SymbolEqualityComparer.Default.Equals(property.ContainingType, m_cultureInfoType);
+	}
+
+	private static bool IsAllowedStyle(ArgumentSyntax? argument, string typeName, SemanticModel semanticModel)
+	{
+		if (argument is null)
+			return true;
+
+		// NumberStyles.None == 0; NumberStyles.Integer == 7; NumberStyles.Float == 167.
+		if (semanticModel.GetConstantValue(argument.Expression).Value is not int value)
+			return false;
+
+		return typeName == "Double" ? value is 0 or 167 : value is 0 or 7;
+	}
+
+	private static string? GetSupportedTypeName(INamedTypeSymbol type) => type.SpecialType switch
+	{
+		SpecialType.System_Boolean => "Boolean",
+		SpecialType.System_Int32 => "Int32",
+		SpecialType.System_Int64 => "Int64",
+		SpecialType.System_Double => "Double",
+		_ => null,
+	};
+
+	private InvariantConvertContext(INamedTypeSymbol cultureInfoType, INamedTypeSymbol numberStylesType, INamedTypeSymbol formatProviderType)
+	{
+		m_cultureInfoType = cultureInfoType;
+		m_numberStylesType = numberStylesType;
+		m_formatProviderType = formatProviderType;
+	}
+
+	private readonly INamedTypeSymbol m_cultureInfoType;
+	private readonly INamedTypeSymbol m_numberStylesType;
+	private readonly INamedTypeSymbol m_formatProviderType;
+}

--- a/src/Faithlife.Analyzers/InvariantConvertKind.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertKind.cs
@@ -1,0 +1,8 @@
+namespace Faithlife.Analyzers;
+
+internal enum InvariantConvertKind
+{
+	Parse,
+	TryParse,
+	ToString,
+}

--- a/src/Faithlife.Analyzers/InvariantConvertMatch.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertMatch.cs
@@ -1,0 +1,24 @@
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Faithlife.Analyzers;
+
+internal sealed class InvariantConvertMatch
+{
+	public InvariantConvertMatch(InvariantConvertKind kind, string suggestedMethodName, ExpressionSyntax valueExpression, ArgumentSyntax? outArgument)
+	{
+		Kind = kind;
+		SuggestedMethodName = suggestedMethodName;
+		ValueExpression = valueExpression;
+		OutArgument = outArgument;
+	}
+
+	public InvariantConvertKind Kind { get; }
+
+	public string SuggestedMethodName { get; }
+
+	// For Parse and TryParse, the string argument being parsed; for ToString, the receiver whose value is being formatted.
+	public ExpressionSyntax ValueExpression { get; }
+
+	// For TryParse, the `out` argument; otherwise null.
+	public ArgumentSyntax? OutArgument { get; }
+}

--- a/src/Faithlife.Analyzers/UseInvariantConvertAnalyzer.cs
+++ b/src/Faithlife.Analyzers/UseInvariantConvertAnalyzer.cs
@@ -1,0 +1,50 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Faithlife.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseInvariantConvertAnalyzer : DiagnosticAnalyzer
+{
+	public override void Initialize(AnalysisContext context)
+	{
+		context.EnableConcurrentExecution();
+		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+		context.RegisterCompilationStartAction(compilationStartAnalysisContext =>
+		{
+			var invariantConvertContext = InvariantConvertContext.TryCreate(compilationStartAnalysisContext.Compilation);
+			if (invariantConvertContext is null)
+				return;
+
+			compilationStartAnalysisContext.RegisterSyntaxNodeAction(c => AnalyzeSyntax(c, invariantConvertContext), SyntaxKind.InvocationExpression);
+		});
+	}
+
+	public const string DiagnosticId = "FL0026";
+
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [s_rule];
+
+	private static void AnalyzeSyntax(SyntaxNodeAnalysisContext context, InvariantConvertContext invariantConvertContext)
+	{
+		var invocation = (InvocationExpressionSyntax) context.Node;
+
+		var match = invariantConvertContext.Match(invocation, context.SemanticModel, context.CancellationToken);
+		if (match is null)
+			return;
+
+		context.ReportDiagnostic(Diagnostic.Create(s_rule, invocation.GetLocation(), match.SuggestedMethodName));
+	}
+
+	private static readonly DiagnosticDescriptor s_rule = new(
+		id: DiagnosticId,
+		title: "Use InvariantConvert",
+		messageFormat: "Use 'InvariantConvert.{0}'",
+		category: "Usage",
+		defaultSeverity: DiagnosticSeverity.Info,
+		isEnabledByDefault: true,
+		helpLinkUri: $"https://github.com/Faithlife/FaithlifeAnalyzers/blob/-/docs/{DiagnosticId}.md");
+}

--- a/src/Faithlife.Analyzers/UseInvariantConvertCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/UseInvariantConvertCodeFixProvider.cs
@@ -1,0 +1,187 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Simplification;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Faithlife.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseInvariantConvertCodeFixProvider)), Shared]
+public sealed class UseInvariantConvertCodeFixProvider : CodeFixProvider
+{
+	public sealed override ImmutableArray<string> FixableDiagnosticIds => [UseInvariantConvertAnalyzer.DiagnosticId];
+
+	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+	public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+	{
+		var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+		if (semanticModel is null)
+			return;
+
+		var invariantConvertContext = InvariantConvertContext.TryCreate(semanticModel.Compilation);
+		if (invariantConvertContext is null)
+			return;
+
+		var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+		if (root is null)
+			return;
+
+		var diagnostic = context.Diagnostics.First();
+		var diagnosticNode = root.FindNode(diagnostic.Location.SourceSpan);
+
+		var invocation = diagnosticNode.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+		if (invocation is null)
+			return;
+
+		var match = invariantConvertContext.Match(invocation, semanticModel, context.CancellationToken);
+		if (match is null)
+			return;
+
+		SyntaxNode replacementTarget;
+		ExpressionSyntax replacement;
+		switch (match.Kind)
+		{
+			case InvariantConvertKind.Parse:
+				replacementTarget = invocation;
+				replacement = ParseExpression($"InvariantConvert.{match.SuggestedMethodName}({match.ValueExpression})");
+				break;
+
+			case InvariantConvertKind.ToString:
+				replacementTarget = invocation;
+				replacement = ParseExpression($"{match.ValueExpression}.ToInvariantString()");
+				break;
+
+			case InvariantConvertKind.TryParse:
+			{
+				var (tryParseTarget, tryParseReplacement) = TryBuildTryParseReplacement(match, invocation, semanticModel);
+				if (tryParseTarget is null || tryParseReplacement is null)
+					return;
+				replacementTarget = tryParseTarget;
+				replacement = tryParseReplacement;
+				break;
+			}
+
+			default:
+				return;
+		}
+
+		context.RegisterCodeFix(
+			CodeAction.Create(
+				title: c_title,
+				createChangedDocument: token => ReplaceValueAsync(context.Document, replacementTarget, replacement.WithTriviaFrom(replacementTarget), token),
+				c_title),
+			diagnostic);
+	}
+
+	private static (SyntaxNode? Target, ExpressionSyntax? Replacement) TryBuildTryParseReplacement(InvariantConvertMatch match, InvocationExpressionSyntax invocation, SemanticModel semanticModel)
+	{
+		// Only rewrite when the out argument declares a named variable: `out var x` / `out int x`.
+		if (match.OutArgument!.Expression is not DeclarationExpressionSyntax declaration)
+			return default;
+		if (declaration.Designation is not SingleVariableDesignationSyntax designation)
+			return default;
+		if (semanticModel.GetDeclaredSymbol(designation) is not ILocalSymbol outLocal)
+			return default;
+
+		// Only rewrite when the invocation is the whole condition of an `if`, optionally negated by a single `!`.
+		bool negated;
+		SyntaxNode replacementTarget;
+		IfStatementSyntax ifStatement;
+		if (invocation.Parent is IfStatementSyntax directIf && directIf.Condition == invocation)
+		{
+			negated = false;
+			replacementTarget = invocation;
+			ifStatement = directIf;
+		}
+		else if (invocation.Parent is PrefixUnaryExpressionSyntax prefix &&
+			prefix.IsKind(SyntaxKind.LogicalNotExpression) &&
+			prefix.Parent is IfStatementSyntax negatedIf &&
+			negatedIf.Condition == prefix)
+		{
+			negated = true;
+			replacementTarget = prefix;
+			ifStatement = negatedIf;
+		}
+		else
+		{
+			return default;
+		}
+
+		// Converting `out var x` to a pattern variable moves where `x` is definitely assigned, so only rewrite
+		// when the result is guaranteed to compile.
+		var thenStatement = ifStatement.Statement;
+		var scope = ifStatement.Ancestors().FirstOrDefault(x => x is BlockSyntax or ArrowExpressionClauseSyntax) ?? ifStatement.Parent;
+		var referencesInThen = false;
+		var referencesOutsideThen = false;
+		if (scope is not null)
+		{
+			foreach (var identifier in scope.DescendantNodes().OfType<IdentifierNameSyntax>())
+			{
+				if (identifier.Identifier.ValueText != designation.Identifier.ValueText)
+					continue;
+				if (!SymbolEqualityComparer.Default.Equals(semanticModel.GetSymbolInfo(identifier).Symbol, outLocal))
+					continue;
+
+				if (thenStatement.Span.Contains(identifier.Span))
+					referencesInThen = true;
+				else
+					referencesOutsideThen = true;
+			}
+		}
+
+		if (negated)
+		{
+			// `if (!TryParse(...)) then`: `x` is only definitely assigned after the `if` when `then` never falls through.
+			if (referencesInThen)
+				return default;
+			var controlFlow = semanticModel.AnalyzeControlFlow(thenStatement);
+			if (controlFlow is not { Succeeded: true, EndPointIsReachable: false })
+				return default;
+		}
+		else
+		{
+			// `if (TryParse(...)) then`: `x` is only in scope within `then`.
+			if (referencesOutsideThen)
+				return default;
+		}
+
+		var notKeyword = negated ? "not " : "";
+		var replacement = ParseExpression($"InvariantConvert.{match.SuggestedMethodName}({match.ValueExpression}) is {notKeyword}{{ }} {designation.Identifier.ValueText}");
+		return (replacementTarget, replacement);
+	}
+
+	private static async Task<Document> ReplaceValueAsync(Document document, SyntaxNode replacementTarget, SyntaxNode replacementNode, CancellationToken cancellationToken)
+	{
+		var root = (CompilationUnitSyntax) (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false))!;
+		root = root.ReplaceNode(replacementTarget, replacementNode);
+
+		// Bring `InvariantConvert` and the `ToInvariantString` extension method into scope.
+		if (!root.Usings.Any(x => AreEquivalent(x.Name, s_invariantNamespace)))
+		{
+			var invariantUsing = UsingDirective(s_invariantNamespace)
+				.WithUsingKeyword(Token(SyntaxKind.UsingKeyword).WithTrailingTrivia(Space))
+				.WithTrailingTrivia(EndOfLine("\n"));
+			root = root.AddUsings(invariantUsing);
+		}
+
+		// Allow the simplifier to remove `using System.Globalization;` if the rewrite made it unnecessary.
+		var globalizationUsing = root.Usings.FirstOrDefault(x => AreEquivalent(x.Name, s_globalizationNamespace));
+		if (globalizationUsing is not null)
+			root = root.ReplaceNode(globalizationUsing, globalizationUsing.WithAdditionalAnnotations(Simplifier.Annotation));
+
+		return await Simplifier.ReduceAsync(
+			await Simplifier.ReduceAsync(document.WithSyntaxRoot(root), cancellationToken: cancellationToken).ConfigureAwait(false),
+			cancellationToken: cancellationToken).ConfigureAwait(false);
+	}
+
+	private static readonly NameSyntax s_invariantNamespace = ParseName("Libronix.Utility.Invariant");
+
+	private static readonly NameSyntax s_globalizationNamespace = ParseName("System.Globalization");
+
+	private const string c_title = "Use InvariantConvert";
+}

--- a/tests/Faithlife.Analyzers.Tests/UseInvariantConvertTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/UseInvariantConvertTests.cs
@@ -1,0 +1,228 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using NUnit.Framework;
+
+namespace Faithlife.Analyzers.Tests;
+
+[TestFixture]
+internal sealed class UseInvariantConvertTests : CodeFixVerifier
+{
+	[TestCase("bool.Parse(input)", "InvariantConvert.ParseBoolean(input)", "ParseBoolean")]
+	[TestCase("Boolean.Parse(input)", "InvariantConvert.ParseBoolean(input)", "ParseBoolean")]
+	[TestCase("int.Parse(input, CultureInfo.InvariantCulture)", "InvariantConvert.ParseInt32(input)", "ParseInt32")]
+	[TestCase("int.Parse(input, NumberStyles.None, CultureInfo.InvariantCulture)", "InvariantConvert.ParseInt32(input)", "ParseInt32")]
+	[TestCase("int.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture)", "InvariantConvert.ParseInt32(input)", "ParseInt32")]
+	[TestCase("Int32.Parse(input, CultureInfo.InvariantCulture)", "InvariantConvert.ParseInt32(input)", "ParseInt32")]
+	[TestCase("double.Parse(input, CultureInfo.InvariantCulture)", "InvariantConvert.ParseDouble(input)", "ParseDouble")]
+	[TestCase("double.Parse(input, NumberStyles.None, CultureInfo.InvariantCulture)", "InvariantConvert.ParseDouble(input)", "ParseDouble")]
+	[TestCase("double.Parse(input, NumberStyles.Float, CultureInfo.InvariantCulture)", "InvariantConvert.ParseDouble(input)", "ParseDouble")]
+	[TestCase("Double.Parse(input, CultureInfo.InvariantCulture)", "InvariantConvert.ParseDouble(input)", "ParseDouble")]
+	[TestCase("long.Parse(input, CultureInfo.InvariantCulture)", "InvariantConvert.ParseInt64(input)", "ParseInt64")]
+	[TestCase("long.Parse(input, NumberStyles.None, CultureInfo.InvariantCulture)", "InvariantConvert.ParseInt64(input)", "ParseInt64")]
+	[TestCase("long.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture)", "InvariantConvert.ParseInt64(input)", "ParseInt64")]
+	[TestCase("Int64.Parse(input, CultureInfo.InvariantCulture)", "InvariantConvert.ParseInt64(input)", "ParseInt64")]
+	[TestCase("boolValue.ToString(CultureInfo.InvariantCulture)", "boolValue.ToInvariantString()", "ToInvariantString")]
+	[TestCase("intValue.ToString(CultureInfo.InvariantCulture)", "intValue.ToInvariantString()", "ToInvariantString")]
+	[TestCase("longValue.ToString(CultureInfo.InvariantCulture)", "longValue.ToInvariantString()", "ToInvariantString")]
+	[TestCase("doubleValue.ToString(CultureInfo.InvariantCulture)", "doubleValue.ToInvariantString()", "ToInvariantString")]
+	public void ParseAndToString(string call, string fixedCall, string suggestedMethod)
+	{
+		var invalidProgram = CreateExpressionProgram(c_preamble, call);
+
+		var expected = new DiagnosticResult
+		{
+			Id = UseInvariantConvertAnalyzer.DiagnosticId,
+			Message = $"Use 'InvariantConvert.{suggestedMethod}'",
+			Severity = DiagnosticSeverity.Info,
+			Locations = [new DiagnosticResultLocation("Test0.cs", s_preambleLength + 7, 11)],
+		};
+
+		VerifyCSharpDiagnostic(invalidProgram, expected);
+		VerifyCSharpFix(invalidProgram, CreateExpressionProgram(s_fixedPreamble, fixedCall));
+	}
+
+	[TestCase("int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var hours)", "InvariantConvert.TryParseInt32(parts[0]) is not { } hours", "TryParseInt32")]
+	[TestCase("int.TryParse(parts[0], CultureInfo.InvariantCulture, out var hours)", "InvariantConvert.TryParseInt32(parts[0]) is not { } hours", "TryParseInt32")]
+	[TestCase("long.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var hours)", "InvariantConvert.TryParseInt64(parts[0]) is not { } hours", "TryParseInt64")]
+	[TestCase("double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var hours)", "InvariantConvert.TryParseDouble(parts[0]) is not { } hours", "TryParseDouble")]
+	[TestCase("bool.TryParse(parts[0], out var hours)", "InvariantConvert.TryParseBoolean(parts[0]) is not { } hours", "TryParseBoolean")]
+	public void NegatedTryParse(string call, string fixedCall, string suggestedMethod)
+	{
+		var invalidProgram = CreateNegatedTryParseProgram(c_preamble, "!" + call);
+
+		var expected = new DiagnosticResult
+		{
+			Id = UseInvariantConvertAnalyzer.DiagnosticId,
+			Message = $"Use 'InvariantConvert.{suggestedMethod}'",
+			Severity = DiagnosticSeverity.Info,
+			Locations = [new DiagnosticResultLocation("Test0.cs", s_preambleLength + 7, 9)],
+		};
+
+		VerifyCSharpDiagnostic(invalidProgram, expected);
+		VerifyCSharpFix(invalidProgram, CreateNegatedTryParseProgram(s_fixedPreamble, fixedCall));
+	}
+
+	[TestCase("int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var minutes)", "InvariantConvert.TryParseInt32(parts[1]) is { } minutes", "TryParseInt32")]
+	[TestCase("long.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var minutes)", "InvariantConvert.TryParseInt64(parts[1]) is { } minutes", "TryParseInt64")]
+	[TestCase("double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var minutes)", "InvariantConvert.TryParseDouble(parts[1]) is { } minutes", "TryParseDouble")]
+	[TestCase("bool.TryParse(parts[1], out var minutes)", "InvariantConvert.TryParseBoolean(parts[1]) is { } minutes", "TryParseBoolean")]
+	public void NonNegatedTryParse(string call, string fixedCall, string suggestedMethod)
+	{
+		var invalidProgram = CreateNonNegatedTryParseProgram(c_preamble, call);
+
+		var expected = new DiagnosticResult
+		{
+			Id = UseInvariantConvertAnalyzer.DiagnosticId,
+			Message = $"Use 'InvariantConvert.{suggestedMethod}'",
+			Severity = DiagnosticSeverity.Info,
+			Locations = [new DiagnosticResultLocation("Test0.cs", s_preambleLength + 7, 8)],
+		};
+
+		VerifyCSharpDiagnostic(invalidProgram, expected);
+		VerifyCSharpFix(invalidProgram, CreateNonNegatedTryParseProgram(s_fixedPreamble, fixedCall));
+	}
+
+	[TestCase("int.Parse(input)")]
+	[TestCase("int.Parse(input, CultureInfo.CurrentCulture)")]
+	[TestCase("int.Parse(input, NumberStyles.HexNumber, CultureInfo.InvariantCulture)")]
+	[TestCase("double.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture)")]
+	[TestCase("decimal.Parse(input, CultureInfo.InvariantCulture)")]
+	[TestCase("intValue.ToString()")]
+	[TestCase("intValue.ToString(\"D\", CultureInfo.InvariantCulture)")]
+	[TestCase("input.ToString(CultureInfo.InvariantCulture)")]
+	public void NoDiagnostic(string call)
+	{
+		VerifyCSharpDiagnostic(CreateExpressionProgram(c_preamble, call));
+	}
+
+	[Test]
+	public void NoDiagnosticWhenTypeNotReferenced()
+	{
+		const string program = """
+			using System;
+			using System.Globalization;
+
+			namespace TestProgram
+			{
+				internal static class TestClass
+				{
+					public static int TestMethod(string input) => int.Parse(input, CultureInfo.InvariantCulture);
+				}
+			}
+			""";
+
+		VerifyCSharpDiagnostic(program);
+	}
+
+	[Test]
+	public void NotFixedInUnsupportedContext()
+	{
+		var invalidProgram = $$"""
+			{{c_preamble}}
+			namespace TestProgram
+			{
+				internal static class TestClass
+				{
+					public static int TestMethod(string input)
+					{
+						var ok = int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value);
+						return ok ? value : 0;
+					}
+				}
+			}
+			""";
+
+		var expected = new DiagnosticResult
+		{
+			Id = UseInvariantConvertAnalyzer.DiagnosticId,
+			Message = "Use 'InvariantConvert.TryParseInt32'",
+			Severity = DiagnosticSeverity.Info,
+			Locations = [new DiagnosticResultLocation("Test0.cs", s_preambleLength + 7, 13)],
+		};
+
+		VerifyCSharpDiagnostic(invalidProgram, expected);
+
+		// The analyzer reports the usage, but the fixer declines to transform it because the
+		// out variable is read on both branches, so the program is left unchanged.
+		VerifyCSharpFix(invalidProgram, invalidProgram);
+	}
+
+	protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new UseInvariantConvertAnalyzer();
+
+	protected override CodeFixProvider GetCSharpCodeFixProvider() => new UseInvariantConvertCodeFixProvider();
+
+	private static string CreateExpressionProgram(string preamble, string statement) => $$"""
+		{{preamble}}
+		namespace TestProgram
+		{
+			internal static class TestClass
+			{
+				public static object TestMethod(string input, bool boolValue, int intValue, long longValue, double doubleValue)
+				{
+					return {{statement}};
+				}
+			}
+		}
+		""";
+
+	private static string CreateNegatedTryParseProgram(string preamble, string condition) => $$"""
+		{{preamble}}
+		namespace TestProgram
+		{
+			internal static class TestClass
+			{
+				public static object TestMethod(string[] parts)
+				{
+					if ({{condition}})
+						return 0;
+					return hours;
+				}
+			}
+		}
+		""";
+
+	private static string CreateNonNegatedTryParseProgram(string preamble, string condition) => $$"""
+		{{preamble}}
+		namespace TestProgram
+		{
+			internal static class TestClass
+			{
+				public static object TestMethod(string[] parts)
+				{
+					if ({{condition}})
+						return minutes;
+					return 0;
+				}
+			}
+		}
+		""";
+
+	private const string c_preamble = """
+		using System;
+		using System.Globalization;
+
+		namespace Libronix.Utility.Invariant
+		{
+			public static class InvariantConvert
+			{
+				public static string ToInvariantString(this bool value) => throw new NotImplementedException();
+				public static bool? TryParseBoolean(string text) => throw new NotImplementedException();
+				public static bool ParseBoolean(string text) => throw new NotImplementedException();
+				public static string ToInvariantString(this double value) => throw new NotImplementedException();
+				public static double? TryParseDouble(string text) => throw new NotImplementedException();
+				public static double ParseDouble(string text) => throw new NotImplementedException();
+				public static string ToInvariantString(this int value) => throw new NotImplementedException();
+				public static int? TryParseInt32(string text) => throw new NotImplementedException();
+				public static int ParseInt32(string text) => throw new NotImplementedException();
+				public static string ToInvariantString(this long value) => throw new NotImplementedException();
+				public static long? TryParseInt64(string text) => throw new NotImplementedException();
+				public static long ParseInt64(string text) => throw new NotImplementedException();
+			}
+		}
+		""";
+
+	private static readonly string s_fixedPreamble = c_preamble.Replace("using System.Globalization;", "using Libronix.Utility.Invariant;", StringComparison.Ordinal);
+
+	private static readonly int s_preambleLength = c_preamble.Split('\n').Length;
+}


### PR DESCRIPTION
Variant of #112 using Claude Opus 4.8 in GitHub Copilot desktop.

## Why

Faithlife code frequently parses and formats values with `CultureInfo.InvariantCulture` (`int.Parse(s, CultureInfo.InvariantCulture)`, `x.ToString(CultureInfo.InvariantCulture)`, etc.). `Libronix.Utility.Invariant.InvariantConvert` provides shorter, harder-to-misuse helpers for the same operations. This analyzer nudges (and can auto-fix) those call sites toward `InvariantConvert`.

## What

Adds analyzer **FL0026 "Use InvariantConvert"** plus a code fix covering `bool`/`int`/`long`/`double` (and full type names `Boolean`/`Int32`/`Int64`/`Double`):

- `int.Parse(s, CultureInfo.InvariantCulture)` -> `InvariantConvert.ParseInt32(s)`
- `int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var x)` -> `InvariantConvert.TryParseInt32(s) is { } x`
- `value.ToString(CultureInfo.InvariantCulture)` -> `value.ToInvariantString()`

The recognizer is shared between the analyzer and fixer (`InvariantConvertContext`). Severity is Info.

## Key design points

- **Gated on availability.** The analyzer only fires when the compilation can resolve `Libronix.Utility.Invariant.InvariantConvert`. If that private package is not referenced, no diagnostics are produced. Tests simulate it with an inline stub type, so the repo's own SelfAnalysis stays clean.
- **Safe TryParse rewrites only.** Converting `out var x` to a pattern variable (`is { } x` / `is not { } x`) moves where `x` is definitely assigned. The fix is therefore limited to cases where the call is the whole `if` condition (optionally negated with a single `!`) and control flow guarantees the result still compiles. In unsupported contexts the diagnostic is reported but no fix is offered.
- **Cleans up usings.** When the rewrite makes `using System.Globalization;` unused, the fix removes it (via the simplifier) and adds `using Libronix.Utility.Invariant;`.

## Notes for reviewers

A few intentional semantic nuances are documented in `docs/FL0026.md`: `NumberStyles.None` is matched even though `InvariantConvert` parses with `Integer`/`Float`; `double` thousands-separator handling differs slightly; and `bool.ToString(...)` yields `"True"`/`"False"` vs `ToInvariantString()`'s `"true"`/`"false"`.

Includes `docs/FL0026.md`, a README table row, a ReleaseNotes entry, and a version bump to 1.7.0. Full test suite passes (265 tests, including 37 new FL0026 cases).