### PR TITLE
Improve FL0026 diagnostic

### DIFF
--- a/docs/FL0026.md
+++ b/docs/FL0026.md
@@ -6,7 +6,6 @@ When this warning appears, add `using Libronix.Utility.Invariant;` and replace t
 
 ## Suggested Fixes
 
-* Replace `bool.Parse(text)` with `InvariantConvert.ParseBoolean(text)`.
 * Replace `int.Parse(text, CultureInfo.InvariantCulture)` with `InvariantConvert.ParseInt32(text)`.
 * Replace `double.Parse(text, CultureInfo.InvariantCulture)` with `InvariantConvert.ParseDouble(text)`.
 * Replace `long.Parse(text, CultureInfo.InvariantCulture)` with `InvariantConvert.ParseInt64(text)`.
@@ -32,4 +31,4 @@ if (InvariantConvert.TryParseInt32(text) is not { } value)
 
 ## Limitations
 
-This analyzer only reports diagnostics when `Libronix.Utility.Invariant.InvariantConvert` is available. `NumberStyles.None` is not reported because `InvariantConvert` accepts the standard invariant styles for each supported type.
+This analyzer only reports diagnostics when `Libronix.Utility.Invariant.InvariantConvert` is available. `NumberStyles.None` is not reported because `InvariantConvert` accepts the standard invariant styles for each supported type. Boolean conversions are not reported because `bool.ToString()` and `bool.ToInvariantString()` produce different strings.

--- a/docs/FL0026.md
+++ b/docs/FL0026.md
@@ -29,6 +29,8 @@ Negated `TryParse` checks use `is not { }`:
 if (InvariantConvert.TryParseInt32(text) is not { } value)
 ```
 
-## Limitations
+## Notes
 
-This analyzer only reports diagnostics when `Libronix.Utility.Invariant.InvariantConvert` is available. `NumberStyles.None` is not reported because `InvariantConvert` accepts the standard invariant styles for each supported type. Boolean conversions are not reported because `bool.ToString()` and `bool.ToInvariantString()` produce different strings.
+* This analyzer only reports diagnostics when `Libronix.Utility.Invariant.InvariantConvert` is available. Add Libronix.Utility to your project first if you want this analyzer to report problemss.
+* `Parse` calls using `NumberStyles.None` are not reported because `InvariantConvert` accepts the standard invariant styles for each supported type. If your code uses `NumberStyles.None`, determine if that's actually required or if you can switch to `InvariantConvert.Parse`.
+* Boolean conversions are not reported because `bool.ToString()` and `bool.ToInvariantString()` produce different strings. Determine whether you need title-case strings and consider switching to `.ToInvariantString()` if not.

--- a/src/Faithlife.Analyzers/InvariantConvertAnalyzer.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertAnalyzer.cs
@@ -27,11 +27,9 @@ public sealed class InvariantConvertAnalyzer : DiagnosticAnalyzer
 
 	internal static bool HasInvariantConvert(Compilation compilation) =>
 		compilation.GetTypeByMetadataName(c_invariantConvertMetadataName) is { } invariantConvertType &&
-		HasMethod(invariantConvertType, "ParseBoolean") &&
 		HasMethod(invariantConvertType, "ParseDouble") &&
 		HasMethod(invariantConvertType, "ParseInt32") &&
 		HasMethod(invariantConvertType, "ParseInt64") &&
-		HasMethod(invariantConvertType, "TryParseBoolean") &&
 		HasMethod(invariantConvertType, "TryParseDouble") &&
 		HasMethod(invariantConvertType, "TryParseInt32") &&
 		HasMethod(invariantConvertType, "TryParseInt64") &&
@@ -73,13 +71,6 @@ public sealed class InvariantConvertAnalyzer : DiagnosticAnalyzer
 		if (inputArgument is null)
 			return null;
 
-		if (conversion.SpecialType == SpecialType.System_Boolean)
-		{
-			return methodSymbol.Parameters.Length == 1 ?
-				InvariantConvertMatch.CreateParse(invocation, conversion.ParseMethodName, inputArgument.Expression) :
-				null;
-		}
-
 		if (methodSymbol.Parameters.Length == 2)
 		{
 			if (GetArgument(arguments, methodSymbol, 1) is { } providerArgument &&
@@ -118,14 +109,6 @@ public sealed class InvariantConvertAnalyzer : DiagnosticAnalyzer
 		var outputArgument = GetArgument(arguments, methodSymbol, methodSymbol.Parameters.Length - 1);
 		if (inputArgument is null || outputArgument is null)
 			return null;
-
-		if (conversion.SpecialType == SpecialType.System_Boolean)
-		{
-			if (methodSymbol.Parameters.Length != 2)
-				return null;
-
-			return CreateTryParseMatch(invocation, conversion.TryParseMethodName, inputArgument.Expression, outputArgument);
-		}
 
 		if (methodSymbol.Parameters.Length == 3)
 		{
@@ -319,7 +302,6 @@ public sealed class InvariantConvertAnalyzer : DiagnosticAnalyzer
 	private static InvariantConvertConversion? GetConversion(SpecialType specialType) =>
 		specialType switch
 		{
-			SpecialType.System_Boolean => s_booleanConversion,
 			SpecialType.System_Double => s_doubleConversion,
 			SpecialType.System_Int32 => s_int32Conversion,
 			SpecialType.System_Int64 => s_int64Conversion,
@@ -338,10 +320,8 @@ public sealed class InvariantConvertAnalyzer : DiagnosticAnalyzer
 	}
 
 	public const string DiagnosticId = "FL0026";
-
 	private const string c_invariantConvertMetadataName = "Libronix.Utility.Invariant.InvariantConvert";
 
-	private static readonly InvariantConvertConversion s_booleanConversion = new(SpecialType.System_Boolean, "ParseBoolean", "TryParseBoolean", "");
 	private static readonly InvariantConvertConversion s_doubleConversion = new(SpecialType.System_Double, "ParseDouble", "TryParseDouble", "Float");
 	private static readonly InvariantConvertConversion s_int32Conversion = new(SpecialType.System_Int32, "ParseInt32", "TryParseInt32", "Integer");
 	private static readonly InvariantConvertConversion s_int64Conversion = new(SpecialType.System_Int64, "ParseInt64", "TryParseInt64", "Integer");

--- a/src/Faithlife.Analyzers/InvariantConvertAnalyzer.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertAnalyzer.cs
@@ -351,7 +351,7 @@ public sealed class InvariantConvertAnalyzer : DiagnosticAnalyzer
 		title: "Use InvariantConvert",
 		messageFormat: "Use InvariantConvert for invariant culture conversions",
 		category: "Usage",
-		defaultSeverity: DiagnosticSeverity.Info,
+		defaultSeverity: DiagnosticSeverity.Warning,
 		isEnabledByDefault: true,
 		helpLinkUri: $"https://github.com/Faithlife/FaithlifeAnalyzers/blob/-/docs/{DiagnosticId}.md");
 }

--- a/src/Faithlife.Analyzers/InvariantConvertAnalyzer.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertAnalyzer.cs
@@ -169,7 +169,7 @@ public sealed class InvariantConvertAnalyzer : DiagnosticAnalyzer
 		if (invocation.Expression is not MemberAccessExpressionSyntax memberAccessExpression)
 			return null;
 
-		if (GetConversion(semanticModel.GetTypeInfo(memberAccessExpression.Expression, cancellationToken).Type?.SpecialType ?? SpecialType.None) is null)
+		if (GetConversion(methodSymbol.ContainingType.SpecialType) is null)
 			return null;
 
 		if (!IsInvariantCulture(invocation.ArgumentList.Arguments[0].Expression, semanticModel, cancellationToken))

--- a/src/Faithlife.Analyzers/InvariantConvertCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertCodeFixProvider.cs
@@ -62,9 +62,10 @@ public sealed class InvariantConvertCodeFixProvider : CodeFixProvider
 		foreach (var namespaceName in s_simplifiableNamespaces)
 			root = SimplifyUsing(root, namespaceName);
 
-		return await Simplifier.ReduceAsync(
+		document = await Simplifier.ReduceAsync(
 			await Simplifier.ReduceAsync(document.WithSyntaxRoot(root), cancellationToken: cancellationToken).ConfigureAwait(false),
 			cancellationToken: cancellationToken).ConfigureAwait(false);
+		return await Formatter.OrganizeImportsAsync(document, cancellationToken).ConfigureAwait(false);
 	}
 
 	private static SyntaxNode GetReplacementTarget(InvariantConvertMatch match)

--- a/src/Faithlife.Analyzers/InvariantConvertCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertCodeFixProvider.cs
@@ -128,7 +128,6 @@ public sealed class InvariantConvertCodeFixProvider : CodeFixProvider
 		ParseName("System.Globalization"),
 		ParseName("System.Globalization.CultureInfo"),
 		ParseName("System.Globalization.NumberStyles"),
-		ParseName("System.Boolean"),
 		ParseName("System.Double"),
 		ParseName("System.Int32"),
 		ParseName("System.Int64"),

--- a/src/Faithlife.Analyzers/InvariantConvertCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertCodeFixProvider.cs
@@ -125,6 +125,7 @@ public sealed class InvariantConvertCodeFixProvider : CodeFixProvider
 	private static readonly SyntaxAnnotation s_addImportsAnnotation = new();
 	private static readonly NameSyntax[] s_simplifiableNamespaces =
 	[
+		ParseName("Libronix.Utility.Invariant"),
 		ParseName("System.Globalization"),
 		ParseName("System.Globalization.CultureInfo"),
 		ParseName("System.Globalization.NumberStyles"),

--- a/src/Faithlife.Analyzers/InvariantConvertCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/InvariantConvertCodeFixProvider.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -49,11 +50,14 @@ public sealed class InvariantConvertCodeFixProvider : CodeFixProvider
 	private static async Task<Document> ReplaceValueAsync(Document document, InvariantConvertMatch match, CancellationToken cancellationToken)
 	{
 		var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-		var replacement = CreateReplacement(match).WithTriviaFrom(match.Invocation).WithAdditionalAnnotations(Formatter.Annotation);
+		var replacement = CreateReplacement(match).WithTriviaFrom(match.Invocation).WithAdditionalAnnotations(
+			Formatter.Annotation,
+			Simplifier.Annotation,
+			s_addImportsAnnotation);
 		root = root.ReplaceNode(GetReplacementTarget(match), replacement);
+		document = await ImportAdder.AddImportsAsync(document.WithSyntaxRoot(root), s_addImportsAnnotation, null, cancellationToken).ConfigureAwait(false);
 
-		if (root is CompilationUnitSyntax compilationUnit)
-			root = AddInvariantUsing(compilationUnit);
+		root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false) ?? root;
 
 		foreach (var namespaceName in s_simplifiableNamespaces)
 			root = SimplifyUsing(root, namespaceName);
@@ -85,11 +89,7 @@ public sealed class InvariantConvertCodeFixProvider : CodeFixProvider
 		{
 			InvariantConvertMatchKind.Parse => CreateInvariantConvertInvocation(match.MethodName, match.InputExpression!),
 			InvariantConvertMatchKind.TryParse => CreateTryParseReplacement(match),
-			InvariantConvertMatchKind.ToString => InvocationExpression(
-				MemberAccessExpression(
-					SyntaxKind.SimpleMemberAccessExpression,
-					match.ReceiverExpression!,
-					IdentifierName("ToInvariantString"))),
+			InvariantConvertMatchKind.ToString => CreateInvariantConvertInvocation(match.MethodName, match.ReceiverExpression!),
 			_ => throw new InvalidOperationException("Unsupported InvariantConvert match."),
 		};
 
@@ -105,7 +105,7 @@ public sealed class InvariantConvertCodeFixProvider : CodeFixProvider
 
 	private static ExpressionSyntax CreateInvariantConvertInvocation(string methodName, ExpressionSyntax inputExpression) =>
 		SyntaxUtility.ReplaceIdentifier(
-			ParseExpression($"InvariantConvert.{methodName}(value)"),
+			ParseExpression($"global::Libronix.Utility.Invariant.InvariantConvert.{methodName}(value)"),
 			"value",
 			inputExpression);
 
@@ -121,22 +121,7 @@ public sealed class InvariantConvertCodeFixProvider : CodeFixProvider
 		return root.ReplaceNode(usingDirective, usingDirective.WithAdditionalAnnotations(Simplifier.Annotation));
 	}
 
-	private static CompilationUnitSyntax AddInvariantUsing(CompilationUnitSyntax root)
-	{
-		foreach (var usingDirective in root.Usings)
-		{
-			if (AreEquivalent(usingDirective.Name, s_invariantNamespace))
-				return root;
-		}
-
-		var trailingTrivia = root.Usings.Count == 0 ?
-			TriviaList(ElasticCarriageReturnLineFeed) :
-			root.Usings.Last().GetTrailingTrivia();
-
-		return root.WithUsings(root.Usings.Add(UsingDirective(s_invariantNamespace).WithTrailingTrivia(trailingTrivia)));
-	}
-
-	private static readonly NameSyntax s_invariantNamespace = ParseName("Libronix.Utility.Invariant");
+	private static readonly SyntaxAnnotation s_addImportsAnnotation = new();
 	private static readonly NameSyntax[] s_simplifiableNamespaces =
 	[
 		ParseName("System.Globalization"),

--- a/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
@@ -407,6 +407,19 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 		VerifyCSharpFix(invalidProgram, fixedProgram);
 	}
 
+	[Test]
+	public void InvariantUsingIsInsertedBeforeOtherNonSystemUsings()
+	{
+		const string invalidStatement = "var result = int.Parse(input, CultureInfo.InvariantCulture);";
+		const string fixedStatement = "var result = InvariantConvert.ParseInt32(input);";
+		const string extraUsings = "using Microsoft.CodeAnalysis;";
+		var invalidProgram = CreateProgram(invalidStatement, extraUsings: extraUsings);
+		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true, extraUsings: extraUsings);
+
+		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, "int.Parse(input, CultureInfo.InvariantCulture)"));
+		VerifyCSharpFix(invalidProgram, fixedProgram);
+	}
+
 	protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new InvariantConvertAnalyzer();
 
 	protected override CodeFixProvider GetCSharpCodeFixProvider() => new InvariantConvertCodeFixProvider();

--- a/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
@@ -408,15 +408,145 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 	}
 
 	[Test]
-	public void InvariantUsingIsInsertedBeforeOtherNonSystemUsings()
+	public void InvariantUsingIsInsertedWithinExistingUsings()
 	{
-		const string invalidStatement = "var result = int.Parse(input, CultureInfo.InvariantCulture);";
-		const string fixedStatement = "var result = InvariantConvert.ParseInt32(input);";
-		const string extraUsings = "using Microsoft.CodeAnalysis;";
-		var invalidProgram = CreateProgram(invalidStatement, extraUsings: extraUsings);
-		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true, extraUsings: extraUsings);
+		const string invalidProgram = $$"""
+			using System;
+			using System.Collections.Generic;
+			using System.Globalization;
+			using System.Linq;
+			using Libronix.Utility;
+			using Microsoft.CodeAnalysis;
+			using Microsoft.CodeAnalysis.CSharp;
 
-		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, "int.Parse(input, CultureInfo.InvariantCulture)"));
+			{{c_invariantConvert}}
+			namespace Libronix.Utility
+			{
+			}
+
+			namespace TestApplication
+			{
+				internal static class TestClass
+				{
+					public static void Test(string input)
+					{
+						var result = int.Parse(input, System.Globalization.CultureInfo.InvariantCulture);
+					}
+				}
+			}
+			""";
+		const string fixedProgram = $$"""
+			using System;
+			using System.Collections.Generic;
+			using System.Linq;
+			using Libronix.Utility;
+			using Libronix.Utility.Invariant;
+			using Microsoft.CodeAnalysis;
+			using Microsoft.CodeAnalysis.CSharp;
+
+			{{c_invariantConvert}}
+			namespace Libronix.Utility
+			{
+			}
+
+			namespace TestApplication
+			{
+				internal static class TestClass
+				{
+					public static void Test(string input)
+					{
+						var result = InvariantConvert.ParseInt32(input);
+					}
+				}
+			}
+			""";
+
+		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, "int.Parse(input, System.Globalization.CultureInfo.InvariantCulture)"));
+		VerifyCSharpFix(invalidProgram, fixedProgram);
+	}
+
+	[Test]
+	public void InvariantUsingIsInsertedWithinExistingLibronixUsingsForToString()
+	{
+		const string invalidProgram = $$"""
+			using System;
+			using System.Collections.Generic;
+			using System.IO;
+			using System.Linq;
+			using Libronix.Utility;
+			using Libronix.Utility.Data;
+			using Libronix.Utility.SQLite;
+			using Logos.ResourceViewTracking.Client;
+
+			{{c_invariantConvert}}
+			namespace Libronix.Utility
+			{
+			}
+
+			namespace Libronix.Utility.Data
+			{
+			}
+
+			namespace Libronix.Utility.SQLite
+			{
+			}
+
+			namespace Logos.ResourceViewTracking.Client
+			{
+			}
+
+			namespace TestApplication
+			{
+				internal static class TestClass
+				{
+					public static void Test(int length)
+					{
+						var result = length.ToString(System.Globalization.CultureInfo.InvariantCulture);
+					}
+				}
+			}
+			""";
+		const string fixedProgram = $$"""
+			using System;
+			using System.Collections.Generic;
+			using System.IO;
+			using System.Linq;
+			using Libronix.Utility;
+			using Libronix.Utility.Data;
+			using Libronix.Utility.Invariant;
+			using Libronix.Utility.SQLite;
+			using Logos.ResourceViewTracking.Client;
+
+			{{c_invariantConvert}}
+			namespace Libronix.Utility
+			{
+			}
+
+			namespace Libronix.Utility.Data
+			{
+			}
+
+			namespace Libronix.Utility.SQLite
+			{
+			}
+
+			namespace Logos.ResourceViewTracking.Client
+			{
+			}
+
+			namespace TestApplication
+			{
+				internal static class TestClass
+				{
+					public static void Test(int length)
+					{
+						var result = length.ToInvariantString();
+					}
+				}
+			}
+			""";
+
+		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, "length.ToString(System.Globalization.CultureInfo.InvariantCulture)"));
 		VerifyCSharpFix(invalidProgram, fixedProgram);
 	}
 

--- a/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
@@ -8,9 +8,6 @@ namespace Faithlife.Analyzers.Tests;
 [TestFixture]
 internal sealed class InvariantConvertTests : CodeFixVerifier
 {
-	[TestCase("var result = bool.Parse(input);", "var result = InvariantConvert.ParseBoolean(input);", "bool.Parse(input)")]
-	[TestCase("var result = Boolean.Parse(input);", "var result = InvariantConvert.ParseBoolean(input);", "Boolean.Parse(input)")]
-	[TestCase("var result = System.Boolean.Parse(input);", "var result = InvariantConvert.ParseBoolean(input);", "System.Boolean.Parse(input)")]
 	[TestCase("var result = int.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt32(input);", "int.Parse(input, CultureInfo.InvariantCulture)")]
 	[TestCase("var result = Int32.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt32(input);", "Int32.Parse(input, CultureInfo.InvariantCulture)")]
 	[TestCase("var result = System.Int32.Parse(input, CultureInfo.InvariantCulture);", "var result = InvariantConvert.ParseInt32(input);", "System.Int32.Parse(input, CultureInfo.InvariantCulture)")]
@@ -38,8 +35,6 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 		VerifyCSharpFix(invalidProgram, fixedProgram);
 	}
 
-	[TestCase("bool.TryParse(input, out var value)", "InvariantConvert.TryParseBoolean(input) is { } value")]
-	[TestCase("Boolean.TryParse(input, out bool value)", "InvariantConvert.TryParseBoolean(input) is { } value")]
 	[TestCase("int.TryParse(input, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseInt32(input) is { } value")]
 	[TestCase("Int32.TryParse(input, CultureInfo.InvariantCulture, out int value)", "InvariantConvert.TryParseInt32(input) is { } value")]
 	[TestCase("int.TryParse(result: out var value, provider: CultureInfo.InvariantCulture, s: input)", "InvariantConvert.TryParseInt32(input) is { } value")]
@@ -62,7 +57,6 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 		VerifyCSharpFix(invalidProgram, fixedProgram);
 	}
 
-	[TestCase("!bool.TryParse(input, out var value)", "InvariantConvert.TryParseBoolean(input) is not { } value", "bool.TryParse(input, out var value)")]
 	[TestCase("!int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseInt32(input) is not { } value", "int.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)")]
 	[TestCase("!double.TryParse(input, NumberStyles.Float, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseDouble(input) is not { } value", "double.TryParse(input, NumberStyles.Float, CultureInfo.InvariantCulture, out var value)")]
 	[TestCase("!long.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)", "InvariantConvert.TryParseInt64(input) is not { } value", "long.TryParse(input, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)")]
@@ -78,7 +72,6 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 		VerifyCSharpFix(invalidProgram, fixedProgram);
 	}
 
-	[TestCase("boolValue", "boolValue.ToString(CultureInfo.InvariantCulture)", "boolValue.ToInvariantString()")]
 	[TestCase("intValue", "intValue.ToString(CultureInfo.InvariantCulture)", "intValue.ToInvariantString()")]
 	[TestCase("doubleValue", "doubleValue.ToString(CultureInfo.InvariantCulture)", "doubleValue.ToInvariantString()")]
 	[TestCase("longValue", "longValue.ToString(CultureInfo.InvariantCulture)", "longValue.ToInvariantString()")]
@@ -156,13 +149,11 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 			Func<ValueFields, string> intFormatter = x => x.IntField.ToString(CultureInfo.InvariantCulture);
 			Func<ValueFields, string> longFormatter = x => x.LongField.ToString(CultureInfo.InvariantCulture);
 			Func<ValueFields, string> doubleFormatter = x => x.DoubleField.ToString(CultureInfo.InvariantCulture);
-			Func<ValueFields, string> boolFormatter = x => x.BoolField.ToString(CultureInfo.InvariantCulture);
 			""";
 		const string fixedStatement = """
 			Func<ValueFields, string> intFormatter = x => x.IntField.ToInvariantString();
 			Func<ValueFields, string> longFormatter = x => x.LongField.ToInvariantString();
 			Func<ValueFields, string> doubleFormatter = x => x.DoubleField.ToInvariantString();
-			Func<ValueFields, string> boolFormatter = x => x.BoolField.ToInvariantString();
 			""";
 		var invalidProgram = CreateProgram(invalidStatement, extraTypes: c_valueFieldTypes);
 		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true, extraTypes: c_valueFieldTypes);
@@ -170,8 +161,7 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 		VerifyCSharpDiagnostic(invalidProgram,
 			CreateDiagnostic(invalidProgram, "x.IntField.ToString(CultureInfo.InvariantCulture)"),
 			CreateDiagnostic(invalidProgram, "x.LongField.ToString(CultureInfo.InvariantCulture)"),
-			CreateDiagnostic(invalidProgram, "x.DoubleField.ToString(CultureInfo.InvariantCulture)"),
-			CreateDiagnostic(invalidProgram, "x.BoolField.ToString(CultureInfo.InvariantCulture)"));
+			CreateDiagnostic(invalidProgram, "x.DoubleField.ToString(CultureInfo.InvariantCulture)"));
 		VerifyCSharpFix(invalidProgram, fixedProgram);
 	}
 
@@ -185,7 +175,6 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 			var parsedProperty = int.Parse(provider.GetText().Value, CultureInfo.InvariantCulture);
 			var parsedElement = long.Parse(values[index], NumberStyles.Integer, CultureInfo.InvariantCulture);
 			var parsedConditional = double.Parse(boolValue ? provider.GetText().Value : input, NumberStyles.Float, CultureInfo.InvariantCulture);
-			var parsedCoalesce = bool.Parse(provider.GetNullableText() ?? input);
 			""";
 		const string fixedStatement = """
 			var provider = new TextProvider();
@@ -194,7 +183,6 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 			var parsedProperty = InvariantConvert.ParseInt32(provider.GetText().Value);
 			var parsedElement = InvariantConvert.ParseInt64(values[index]);
 			var parsedConditional = InvariantConvert.ParseDouble(boolValue ? provider.GetText().Value : input);
-			var parsedCoalesce = InvariantConvert.ParseBoolean(provider.GetNullableText() ?? input);
 			""";
 		var invalidProgram = CreateProgram(invalidStatement, extraTypes: c_textProviderTypes);
 		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true, extraTypes: c_textProviderTypes);
@@ -202,8 +190,7 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 		VerifyCSharpDiagnostic(invalidProgram,
 			CreateDiagnostic(invalidProgram, "int.Parse(provider.GetText().Value, CultureInfo.InvariantCulture)"),
 			CreateDiagnostic(invalidProgram, "long.Parse(values[index], NumberStyles.Integer, CultureInfo.InvariantCulture)"),
-			CreateDiagnostic(invalidProgram, "double.Parse(boolValue ? provider.GetText().Value : input, NumberStyles.Float, CultureInfo.InvariantCulture)"),
-			CreateDiagnostic(invalidProgram, "bool.Parse(provider.GetNullableText() ?? input)"));
+			CreateDiagnostic(invalidProgram, "double.Parse(boolValue ? provider.GetText().Value : input, NumberStyles.Float, CultureInfo.InvariantCulture)"));
 		VerifyCSharpFix(invalidProgram, fixedProgram);
 	}
 
@@ -227,6 +214,25 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 	public void UnsupportedUsage(string statement)
 	{
 		VerifyCSharpDiagnostic(CreateProgram(statement));
+	}
+
+	[Test]
+	public void BoolConversionsAreUnsupported()
+	{
+		const string statement = """
+			var parsed = bool.Parse(input);
+			var parsedType = Boolean.Parse(input);
+			var parsedQualified = System.Boolean.Parse(input);
+			var parsedCoalesce = bool.Parse(new TextProvider().GetNullableText() ?? input);
+			if (bool.TryParse(input, out var parsedValue))
+				GC.KeepAlive(parsedValue);
+			if (!bool.TryParse(input, out var negatedValue))
+				return;
+			var formatted = boolValue.ToString(CultureInfo.InvariantCulture);
+			Func<ValueFields, string> formatter = x => x.BoolField.ToString(CultureInfo.InvariantCulture);
+			""";
+
+		VerifyCSharpDiagnostic(CreateProgram(statement, extraTypes: c_valueFieldTypes + "\n\n" + c_textProviderTypes));
 	}
 
 	[Test]
@@ -676,9 +682,6 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 		{
 			public static class InvariantConvert
 			{
-				public static string ToInvariantString(this bool value) => throw new NotImplementedException();
-				public static bool? TryParseBoolean(string text) => throw new NotImplementedException();
-				public static bool ParseBoolean(string text) => throw new NotImplementedException();
 				public static string ToInvariantString(this double value) => throw new NotImplementedException();
 				public static double? TryParseDouble(string text) => throw new NotImplementedException();
 				public static double ParseDouble(string text) => throw new NotImplementedException();

--- a/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
@@ -94,6 +94,120 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 	}
 
 	[Test]
+	public void ToStringClassPropertyReceiversAreFixed()
+	{
+		const string invalidStatement = """
+			var record = new DataRecord();
+			var length = record.Segment.Length.ToString(CultureInfo.InvariantCulture);
+			var offset = record.Segment.Offset.ToString(CultureInfo.InvariantCulture);
+			""";
+		const string fixedStatement = """
+			var record = new DataRecord();
+			var length = record.Segment.Length.ToInvariantString();
+			var offset = record.Segment.Offset.ToInvariantString();
+			""";
+		var invalidProgram = CreateProgram(invalidStatement, extraTypes: c_segmentTypes);
+		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true, extraTypes: c_segmentTypes);
+
+		VerifyCSharpDiagnostic(invalidProgram,
+			CreateDiagnostic(invalidProgram, "record.Segment.Length.ToString(CultureInfo.InvariantCulture)"),
+			CreateDiagnostic(invalidProgram, "record.Segment.Offset.ToString(CultureInfo.InvariantCulture)"));
+		VerifyCSharpFix(invalidProgram, fixedProgram);
+	}
+
+	[Test]
+	public void ToStringMethodCallReceiversAreFixed()
+	{
+		const string invalidStatement = """
+			var provider = new ValueProvider();
+			var length = provider.GetLength().ToString(CultureInfo.InvariantCulture);
+			var offset = provider.GetSegment().Offset.ToString(CultureInfo.InvariantCulture);
+			""";
+		const string fixedStatement = """
+			var provider = new ValueProvider();
+			var length = provider.GetLength().ToInvariantString();
+			var offset = provider.GetSegment().Offset.ToInvariantString();
+			""";
+		var invalidProgram = CreateProgram(invalidStatement, extraTypes: c_segmentTypes);
+		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true, extraTypes: c_segmentTypes);
+
+		VerifyCSharpDiagnostic(invalidProgram,
+			CreateDiagnostic(invalidProgram, "provider.GetLength().ToString(CultureInfo.InvariantCulture)"),
+			CreateDiagnostic(invalidProgram, "provider.GetSegment().Offset.ToString(CultureInfo.InvariantCulture)"));
+		VerifyCSharpFix(invalidProgram, fixedProgram);
+	}
+
+	[Test]
+	public void ToStringLambdaParameterReceiversAreFixed()
+	{
+		const string invalidStatement = "Func<int, string> formatter = x => x.ToString(CultureInfo.InvariantCulture);";
+		const string fixedStatement = "Func<int, string> formatter = x => x.ToInvariantString();";
+		var invalidProgram = CreateProgram(invalidStatement);
+		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true);
+
+		VerifyCSharpDiagnostic(invalidProgram, CreateDiagnostic(invalidProgram, "x.ToString(CultureInfo.InvariantCulture)"));
+		VerifyCSharpFix(invalidProgram, fixedProgram);
+	}
+
+	[Test]
+	public void ToStringLambdaMemberAccessReceiversAreFixed()
+	{
+		const string invalidStatement = """
+			Func<ValueFields, string> intFormatter = x => x.IntField.ToString(CultureInfo.InvariantCulture);
+			Func<ValueFields, string> longFormatter = x => x.LongField.ToString(CultureInfo.InvariantCulture);
+			Func<ValueFields, string> doubleFormatter = x => x.DoubleField.ToString(CultureInfo.InvariantCulture);
+			Func<ValueFields, string> boolFormatter = x => x.BoolField.ToString(CultureInfo.InvariantCulture);
+			""";
+		const string fixedStatement = """
+			Func<ValueFields, string> intFormatter = x => x.IntField.ToInvariantString();
+			Func<ValueFields, string> longFormatter = x => x.LongField.ToInvariantString();
+			Func<ValueFields, string> doubleFormatter = x => x.DoubleField.ToInvariantString();
+			Func<ValueFields, string> boolFormatter = x => x.BoolField.ToInvariantString();
+			""";
+		var invalidProgram = CreateProgram(invalidStatement, extraTypes: c_valueFieldTypes);
+		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true, extraTypes: c_valueFieldTypes);
+
+		VerifyCSharpDiagnostic(invalidProgram,
+			CreateDiagnostic(invalidProgram, "x.IntField.ToString(CultureInfo.InvariantCulture)"),
+			CreateDiagnostic(invalidProgram, "x.LongField.ToString(CultureInfo.InvariantCulture)"),
+			CreateDiagnostic(invalidProgram, "x.DoubleField.ToString(CultureInfo.InvariantCulture)"),
+			CreateDiagnostic(invalidProgram, "x.BoolField.ToString(CultureInfo.InvariantCulture)"));
+		VerifyCSharpFix(invalidProgram, fixedProgram);
+	}
+
+	[Test]
+	public void ParseComplexInputExpressionsAreFixed()
+	{
+		const string invalidStatement = """
+			var provider = new TextProvider();
+			var index = 0;
+			var values = new[] { "1", "2" };
+			var parsedProperty = int.Parse(provider.GetText().Value, CultureInfo.InvariantCulture);
+			var parsedElement = long.Parse(values[index], NumberStyles.Integer, CultureInfo.InvariantCulture);
+			var parsedConditional = double.Parse(boolValue ? provider.GetText().Value : input, NumberStyles.Float, CultureInfo.InvariantCulture);
+			var parsedCoalesce = bool.Parse(provider.GetNullableText() ?? input);
+			""";
+		const string fixedStatement = """
+			var provider = new TextProvider();
+			var index = 0;
+			var values = new[] { "1", "2" };
+			var parsedProperty = InvariantConvert.ParseInt32(provider.GetText().Value);
+			var parsedElement = InvariantConvert.ParseInt64(values[index]);
+			var parsedConditional = InvariantConvert.ParseDouble(boolValue ? provider.GetText().Value : input);
+			var parsedCoalesce = InvariantConvert.ParseBoolean(provider.GetNullableText() ?? input);
+			""";
+		var invalidProgram = CreateProgram(invalidStatement, extraTypes: c_textProviderTypes);
+		var fixedProgram = CreateProgram(fixedStatement, includeSystemGlobalization: false, includeInvariantUsing: true, extraTypes: c_textProviderTypes);
+
+		VerifyCSharpDiagnostic(invalidProgram,
+			CreateDiagnostic(invalidProgram, "int.Parse(provider.GetText().Value, CultureInfo.InvariantCulture)"),
+			CreateDiagnostic(invalidProgram, "long.Parse(values[index], NumberStyles.Integer, CultureInfo.InvariantCulture)"),
+			CreateDiagnostic(invalidProgram, "double.Parse(boolValue ? provider.GetText().Value : input, NumberStyles.Float, CultureInfo.InvariantCulture)"),
+			CreateDiagnostic(invalidProgram, "bool.Parse(provider.GetNullableText() ?? input)"));
+		VerifyCSharpFix(invalidProgram, fixedProgram);
+	}
+
+	[Test]
 	public void NoDiagnosticWithoutInvariantConvert()
 	{
 		VerifyCSharpDiagnostic(CreateProgram("var result = int.Parse(input, CultureInfo.InvariantCulture);", includeInvariantConvert: false));
@@ -335,7 +449,7 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 	}
 
 	private static string CreateProgram(string statement, bool includeInvariantConvert = true, bool includeSystemGlobalization = true,
-		bool includeInvariantUsing = false, string extraUsings = "")
+		bool includeInvariantUsing = false, string extraUsings = "", string extraTypes = "")
 	{
 		var usings = "using System;";
 		if (includeSystemGlobalization)
@@ -360,9 +474,59 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 						{{statement}}
 					}
 				}
+
+				{{extraTypes}}
 			}
 			""";
 	}
+
+	private const string c_segmentTypes = """
+		internal sealed class DataRecord
+		{
+			public Segment Segment { get; } = new();
+		}
+
+		internal sealed class Segment
+		{
+			public int Length { get; set; }
+
+			public int Offset { get; set; }
+		}
+
+		internal sealed class ValueProvider
+		{
+			public int GetLength() => 0;
+
+			public Segment GetSegment() => new();
+		}
+		""";
+
+	private const string c_valueFieldTypes = """
+		internal sealed class ValueFields
+		{
+			public int IntField;
+
+			public long LongField;
+
+			public double DoubleField;
+
+			public bool BoolField;
+		}
+		""";
+
+	private const string c_textProviderTypes = """
+		internal sealed class TextProvider
+		{
+			public TextRecord GetText() => new();
+
+			public string GetNullableText() => null!;
+		}
+
+		internal sealed class TextRecord
+		{
+			public string Value { get; } = "";
+		}
+		""";
 
 	private const string c_invariantConvert = """
 		namespace Libronix.Utility.Invariant

--- a/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
@@ -443,7 +443,7 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 		{
 			Id = InvariantConvertAnalyzer.DiagnosticId,
 			Message = "Use InvariantConvert for invariant culture conversions",
-			Severity = DiagnosticSeverity.Info,
+			Severity = DiagnosticSeverity.Warning,
 			Locations = [new DiagnosticResultLocation("Test0.cs", line, column)],
 		};
 	}

--- a/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/InvariantConvertTests.cs
@@ -426,10 +426,6 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 			using Microsoft.CodeAnalysis.CSharp;
 
 			{{c_invariantConvert}}
-			namespace Libronix.Utility
-			{
-			}
-
 			namespace TestApplication
 			{
 				internal static class TestClass
@@ -451,10 +447,6 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 			using Microsoft.CodeAnalysis.CSharp;
 
 			{{c_invariantConvert}}
-			namespace Libronix.Utility
-			{
-			}
-
 			namespace TestApplication
 			{
 				internal static class TestClass
@@ -477,30 +469,12 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 		const string invalidProgram = $$"""
 			using System;
 			using System.Collections.Generic;
-			using System.IO;
 			using System.Linq;
 			using Libronix.Utility;
-			using Libronix.Utility.Data;
-			using Libronix.Utility.SQLite;
-			using Logos.ResourceViewTracking.Client;
+			using Microsoft.CodeAnalysis;
+			using Microsoft.CodeAnalysis.CSharp;
 
 			{{c_invariantConvert}}
-			namespace Libronix.Utility
-			{
-			}
-
-			namespace Libronix.Utility.Data
-			{
-			}
-
-			namespace Libronix.Utility.SQLite
-			{
-			}
-
-			namespace Logos.ResourceViewTracking.Client
-			{
-			}
-
 			namespace TestApplication
 			{
 				internal static class TestClass
@@ -515,31 +489,13 @@ internal sealed class InvariantConvertTests : CodeFixVerifier
 		const string fixedProgram = $$"""
 			using System;
 			using System.Collections.Generic;
-			using System.IO;
 			using System.Linq;
 			using Libronix.Utility;
-			using Libronix.Utility.Data;
 			using Libronix.Utility.Invariant;
-			using Libronix.Utility.SQLite;
-			using Logos.ResourceViewTracking.Client;
+			using Microsoft.CodeAnalysis;
+			using Microsoft.CodeAnalysis.CSharp;
 
 			{{c_invariantConvert}}
-			namespace Libronix.Utility
-			{
-			}
-
-			namespace Libronix.Utility.Data
-			{
-			}
-
-			namespace Libronix.Utility.SQLite
-			{
-			}
-
-			namespace Logos.ResourceViewTracking.Client
-			{
-			}
-
 			namespace TestApplication
 			{
 				internal static class TestClass


### PR DESCRIPTION
## Summary
- Add FL0026 regression coverage for production-shaped `ToString(CultureInfo.InvariantCulture)` receivers, including class property chains, method call receivers, lambda parameters, and lambda member access.
- Add parse fixer coverage for nested method/property access, element access, conditionals, and coalescing input expressions.
- Match `ToString` conversions from the resolved primitive overload symbol instead of re-deriving the receiver type from syntax.
- Use Roslyn `ImportAdder` plus `Formatter.OrganizeImportsAsync` so added `Libronix.Utility.Invariant` imports are ordered with existing usings, including existing `Libronix.Utility.*` groups.
- Exclude bool from FL0026 parse, try-parse, and invariant-string conversions because `bool.ToString()` and `bool.ToInvariantString()` are not equivalent.

## Validation
- `dotnet test .\tests\Faithlife.Analyzers.Tests\Faithlife.Analyzers.Tests.csproj --filter InvariantConvertTests --nologo --verbosity minimal`
- `.\build.ps1 test`