### PR TITLE
Handle conditional-access IfNotNull fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.7.1</VersionPrefix>
+    <VersionPrefix>1.7.2</VersionPrefix>
     <NoWarn>$(NoWarn);1591;1998;NU5105;CA1014;CA1508;CA1859;NU1507</NoWarn>
     <GitHubOrganization>Faithlife</GitHubOrganization>
     <RepositoryName>FaithlifeAnalyzers</RepositoryName>

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -3,6 +3,7 @@
 ## 1.7.2
 
 * Fix FL0010 code-fix handling for conditional-access invocations such as `possiblyNull?.IfNotNull(...)` so they apply without crashing.
+* Simplify `IfNotNull` fixer output to use default literals.
 
 ## 1.7.1
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 1.7.2
+
+* Fix FL0010 code-fix handling for conditional-access invocations such as `possiblyNull?.IfNotNull(...)` so they apply without crashing.
+
 ## 1.7.1
 
 * FL0025: Don't flag static fields or fields with preprocessor directives above them, since auto-fixing either can introduce bugs without compiler errors.

--- a/src/Faithlife.Analyzers/IfNotNullCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/IfNotNullCodeFixProvider.cs
@@ -110,7 +110,7 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 
 		if (methodSymbol.Arity == 2)
 		{
-			// Explicitly supplying default(SomeType) or null is identical to not supplying anything.
+			// Explicitly supplying default, default(SomeType), or null is identical to not supplying anything.
 			// However, the presence of a defaultValueExpression will prevent us from using
 			// the most concise formulation for reference types. Clearing this out allows the other
 			// optimizations to take place.
@@ -122,7 +122,9 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 			// evaluates to the correct type.
 			if (outputTypeIsNullable &&
 				(defaultValueExpression is DefaultExpressionSyntax ||
-					(defaultValueExpression is LiteralExpressionSyntax defaultLiteral && defaultLiteral.IsKind(SyntaxKind.NullLiteralExpression))))
+					defaultValueExpression is LiteralExpressionSyntax defaultOrNullLiteral &&
+						(defaultOrNullLiteral.IsKind(SyntaxKind.DefaultLiteralExpression) ||
+						defaultOrNullLiteral.IsKind(SyntaxKind.NullLiteralExpression))))
 			{
 				defaultValueExpression = null;
 			}
@@ -131,7 +133,7 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 				if (!outputTypeArgument!.CanBeReferencedByName)
 					return;
 
-				defaultValueExpression = DefaultExpression(GetTypeSyntax(outputTypeArgument));
+				defaultValueExpression = LiteralExpression(SyntaxKind.DefaultLiteralExpression);
 			}
 		}
 
@@ -377,7 +379,7 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 			replacementExpression = ConditionalExpression(
 				conditionExpression,
 				SyntaxUtility.SimplifiableParentheses(lambdaExpressionBody),
-				defaultValueExpression ?? DefaultExpression(GetTypeSyntax(outputTypeArgument!))); // TODO: verify this null coercion is safe
+				defaultValueExpression ?? LiteralExpression(SyntaxKind.DefaultLiteralExpression)); // TODO: verify this null coercion is safe
 		}
 		else
 		{

--- a/src/Faithlife.Analyzers/IfNotNullCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/IfNotNullCodeFixProvider.cs
@@ -110,7 +110,7 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 
 		if (methodSymbol.Arity == 2)
 		{
-			// Explicitly supplying default, default(SomeType), or null is identical to not supplying anything.
+			// Explicitly supplying default(SomeType) or null is identical to not supplying anything.
 			// However, the presence of a defaultValueExpression will prevent us from using
 			// the most concise formulation for reference types. Clearing this out allows the other
 			// optimizations to take place.
@@ -122,9 +122,7 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 			// evaluates to the correct type.
 			if (outputTypeIsNullable &&
 				(defaultValueExpression is DefaultExpressionSyntax ||
-					defaultValueExpression is LiteralExpressionSyntax defaultOrNullLiteral &&
-						(defaultOrNullLiteral.IsKind(SyntaxKind.DefaultLiteralExpression) ||
-						defaultOrNullLiteral.IsKind(SyntaxKind.NullLiteralExpression))))
+					(defaultValueExpression is LiteralExpressionSyntax defaultLiteral && defaultLiteral.IsKind(SyntaxKind.NullLiteralExpression))))
 			{
 				defaultValueExpression = null;
 			}

--- a/src/Faithlife.Analyzers/IfNotNullCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/IfNotNullCodeFixProvider.cs
@@ -46,7 +46,9 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 		// The location of each of the arguments changes based on whether the method is invoked as an extension method.
 		var targetExpression = methodSymbol.IsStatic ?
 			ifNotNullInvocation.ArgumentList.Arguments[0].Expression :
-			((MemberAccessExpressionSyntax) ifNotNullInvocation.Expression).Expression;
+			GetInvocationTargetExpression(ifNotNullInvocation);
+		if (targetExpression is null)
+			return;
 
 		var delegateExpression = methodSymbol.IsStatic ?
 			ifNotNullInvocation.ArgumentList.Arguments[1].Expression :
@@ -267,7 +269,7 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 							title: "Use conditional access operator",
 							createChangedDocument: token => ReplaceValueAsync(
 								context.Document,
-								ifNotNullInvocation,
+								GetReplacementTarget(ifNotNullInvocation),
 								finalExpression,
 								token),
 							c_fixName),
@@ -337,7 +339,7 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 			return;
 		}
 
-		ExpressionSyntax replacementTarget;
+		SyntaxNode replacementTarget;
 		ExpressionSyntax replacementExpression;
 
 		if (defaultValueExpression is null &&
@@ -357,7 +359,7 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 		}
 		else if (defaultValueExpression is object || outputTypeArgument!.CanBeReferencedByName) //// TODO: verify this null coercion is safe
 		{
-			replacementTarget = ifNotNullInvocation;
+			replacementTarget = GetReplacementTarget(ifNotNullInvocation);
 			replacementExpression = ConditionalExpression(
 				conditionExpression,
 				SyntaxUtility.SimplifiableParentheses(lambdaExpressionBody),
@@ -422,6 +424,29 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 		}
 
 		return currentExpression;
+	}
+
+	private static ExpressionSyntax? GetInvocationTargetExpression(InvocationExpressionSyntax ifNotNullInvocation)
+	{
+		if (ifNotNullInvocation.Expression is MemberAccessExpressionSyntax memberAccess)
+			return memberAccess.Expression;
+
+		if (ifNotNullInvocation.Expression is MemberBindingExpressionSyntax or ElementBindingExpressionSyntax &&
+			ifNotNullInvocation.Parent is ConditionalAccessExpressionSyntax conditionalAccess &&
+			conditionalAccess.WhenNotNull == ifNotNullInvocation)
+			return conditionalAccess.Expression;
+
+		return null;
+	}
+
+	private static SyntaxNode GetReplacementTarget(InvocationExpressionSyntax ifNotNullInvocation)
+	{
+		if (ifNotNullInvocation.Expression is MemberBindingExpressionSyntax or ElementBindingExpressionSyntax &&
+			ifNotNullInvocation.Parent is ConditionalAccessExpressionSyntax conditionalAccess &&
+			conditionalAccess.WhenNotNull == ifNotNullInvocation)
+			return conditionalAccess;
+
+		return ifNotNullInvocation;
 	}
 
 	private static async Task<Document> ReplaceValueAsync(Document document, SyntaxNode replacementTarget, SyntaxNode replacementNode, CancellationToken cancellationToken)

--- a/src/Faithlife.Analyzers/IfNotNullCodeFixProvider.cs
+++ b/src/Faithlife.Analyzers/IfNotNullCodeFixProvider.cs
@@ -46,7 +46,13 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 		// The location of each of the arguments changes based on whether the method is invoked as an extension method.
 		var targetExpression = methodSymbol.IsStatic ?
 			ifNotNullInvocation.ArgumentList.Arguments[0].Expression :
-			GetInvocationTargetExpression(ifNotNullInvocation);
+			ifNotNullInvocation.Expression switch
+			{
+				MemberAccessExpressionSyntax memberAccess => memberAccess.Expression,
+				MemberBindingExpressionSyntax memberBinding => (memberBinding.Parent.Parent as ConditionalAccessExpressionSyntax)?.Expression,
+				ElementBindingExpressionSyntax elementBinding => (elementBinding.Parent.Parent as ConditionalAccessExpressionSyntax)?.Expression,
+				_ => null,
+			};
 		if (targetExpression is null)
 			return;
 
@@ -269,7 +275,11 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 							title: "Use conditional access operator",
 							createChangedDocument: token => ReplaceValueAsync(
 								context.Document,
-								GetReplacementTarget(ifNotNullInvocation),
+								ifNotNullInvocation.Expression is MemberBindingExpressionSyntax or ElementBindingExpressionSyntax &&
+								ifNotNullInvocation.Parent is ConditionalAccessExpressionSyntax conditionalAccess &&
+								conditionalAccess.WhenNotNull == ifNotNullInvocation
+									? conditionalAccess
+									: ifNotNullInvocation,
 								finalExpression,
 								token),
 							c_fixName),
@@ -359,7 +369,11 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 		}
 		else if (defaultValueExpression is object || outputTypeArgument!.CanBeReferencedByName) //// TODO: verify this null coercion is safe
 		{
-			replacementTarget = GetReplacementTarget(ifNotNullInvocation);
+			replacementTarget = ifNotNullInvocation.Expression is MemberBindingExpressionSyntax or ElementBindingExpressionSyntax &&
+				ifNotNullInvocation.Parent is ConditionalAccessExpressionSyntax conditionalAccess &&
+				conditionalAccess.WhenNotNull == ifNotNullInvocation
+					? conditionalAccess
+					: ifNotNullInvocation;
 			replacementExpression = ConditionalExpression(
 				conditionExpression,
 				SyntaxUtility.SimplifiableParentheses(lambdaExpressionBody),
@@ -424,29 +438,6 @@ public sealed class IfNotNullCodeFixProvider : CodeFixProvider
 		}
 
 		return currentExpression;
-	}
-
-	private static ExpressionSyntax? GetInvocationTargetExpression(InvocationExpressionSyntax ifNotNullInvocation)
-	{
-		if (ifNotNullInvocation.Expression is MemberAccessExpressionSyntax memberAccess)
-			return memberAccess.Expression;
-
-		if (ifNotNullInvocation.Expression is MemberBindingExpressionSyntax or ElementBindingExpressionSyntax &&
-			ifNotNullInvocation.Parent is ConditionalAccessExpressionSyntax conditionalAccess &&
-			conditionalAccess.WhenNotNull == ifNotNullInvocation)
-			return conditionalAccess.Expression;
-
-		return null;
-	}
-
-	private static SyntaxNode GetReplacementTarget(InvocationExpressionSyntax ifNotNullInvocation)
-	{
-		if (ifNotNullInvocation.Expression is MemberBindingExpressionSyntax or ElementBindingExpressionSyntax &&
-			ifNotNullInvocation.Parent is ConditionalAccessExpressionSyntax conditionalAccess &&
-			conditionalAccess.WhenNotNull == ifNotNullInvocation)
-			return conditionalAccess;
-
-		return ifNotNullInvocation;
 	}
 
 	private static async Task<Document> ReplaceValueAsync(Document document, SyntaxNode replacementTarget, SyntaxNode replacementNode, CancellationToken cancellationToken)

--- a/tests/Faithlife.Analyzers.Tests/IfNotNullTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/IfNotNullTests.cs
@@ -154,6 +154,17 @@ internal sealed class IfNotNullTests : CodeFixVerifier
 		"var result = IfNotNullExtensionMethod.IfNotNull(possiblyNull, (ValueThing x) => x.ValueTypeProperty, () => 0);",
 		"var result = possiblyNull?.ValueTypeProperty ?? 0;")]
 
+	// Explicitly supplying default(SomeType) as the default value is identical to not supplying one:
+	// it should be cleared out so that the most concise conditional-access form is still used.
+	[TestCase(
+		"new ReferenceThing()",
+		"var result = possiblyNull.IfNotNull(x => x.CalculateValue(), default(ReferenceThing));",
+		"var result = possiblyNull?.CalculateValue();")]
+	[TestCase(
+		"new ReferenceThing()",
+		"var result = possiblyNull.IfNotNull(x => x.NullableProperty, default(int?));",
+		"var result = possiblyNull?.NullableProperty;")]
+
 	// Supplying a reference type default value requires falling back to pattern matching.
 	[TestCase(
 		"new ReferenceThing()",

--- a/tests/Faithlife.Analyzers.Tests/IfNotNullTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/IfNotNullTests.cs
@@ -13,13 +13,13 @@ internal sealed class IfNotNullTests : CodeFixVerifier
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.IfNotNull(x => x.ValueTypeProperty);",
-		"var result = possiblyNull?.ValueTypeProperty ?? default(int);")]
+		"var result = possiblyNull?.ValueTypeProperty ?? default;")]
 
 	// Complex expressions of a value type still need the null coalescing operator
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.IfNotNull(x => x.CalculateValue().ValueTypeProperty);",
-		"var result = possiblyNull?.CalculateValue().ValueTypeProperty ?? default(int);")]
+		"var result = possiblyNull?.CalculateValue().ValueTypeProperty ?? default;")]
 
 	// Most usages of the default parameter cannot be combined with the conditional operator,
 	// but value types are fine.
@@ -51,42 +51,42 @@ internal sealed class IfNotNullTests : CodeFixVerifier
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.IfNotNull(x => (x.CalculateValue()));",
-		"var result = possiblyNull is ReferenceThing ? (possiblyNull.CalculateValue()) : default(ReferenceThing);")]
+		"var result = possiblyNull is ReferenceThing ? (possiblyNull.CalculateValue()) : default;")]
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.RecursiveProperty.IfNotNull(x => (x.CalculateValue()));",
-		"var result = possiblyNull.RecursiveProperty is ReferenceThing x ? (x.CalculateValue()) : default(ReferenceThing);")]
+		"var result = possiblyNull.RecursiveProperty is ReferenceThing x ? (x.CalculateValue()) : default;")]
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.IfNotNull(x => (x).CalculateValue());",
-		"var result = possiblyNull is ReferenceThing ? (possiblyNull).CalculateValue() : default(ReferenceThing);")]
+		"var result = possiblyNull is ReferenceThing ? (possiblyNull).CalculateValue() : default;")]
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.RecursiveProperty.IfNotNull(x => (x).CalculateValue());",
-		"var result = possiblyNull.RecursiveProperty is ReferenceThing x ? (x).CalculateValue() : default(ReferenceThing);")]
+		"var result = possiblyNull.RecursiveProperty is ReferenceThing x ? (x).CalculateValue() : default;")]
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.IfNotNull(x => (x.RecursiveProperty).CalculateValue());",
-		"var result = possiblyNull is ReferenceThing ? (possiblyNull.RecursiveProperty).CalculateValue() : default(ReferenceThing);")]
+		"var result = possiblyNull is ReferenceThing ? (possiblyNull.RecursiveProperty).CalculateValue() : default;")]
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.IfNotNull(x => ((x.RecursiveProperty).RecursiveProperty).CalculateValue());",
-		"var result = possiblyNull is ReferenceThing ? ((possiblyNull.RecursiveProperty).RecursiveProperty).CalculateValue() : default(ReferenceThing);")]
+		"var result = possiblyNull is ReferenceThing ? ((possiblyNull.RecursiveProperty).RecursiveProperty).CalculateValue() : default;")]
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.IfNotNull(x => (x.RecursiveProperty?.RecursiveProperty).CalculateValue());",
-		"var result = possiblyNull is ReferenceThing ? (possiblyNull.RecursiveProperty?.RecursiveProperty).CalculateValue() : default(ReferenceThing);")]
+		"var result = possiblyNull is ReferenceThing ? (possiblyNull.RecursiveProperty?.RecursiveProperty).CalculateValue() : default;")]
 
 	// When using pattern matching, the input type must be used for the declaration type.
 	// (in most of these tests, the input type and output type are the same)
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.IfNotNull(x => (x.ValueTypeProperty));",
-		"var result = possiblyNull is ReferenceThing ? (possiblyNull.ValueTypeProperty) : default(int);")]
+		"var result = possiblyNull is ReferenceThing ? (possiblyNull.ValueTypeProperty) : default;")]
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.RecursiveProperty.IfNotNull(x => (x.ValueTypeProperty));",
-		"var result = possiblyNull.RecursiveProperty is ReferenceThing x ? (x.ValueTypeProperty) : default(int);")]
+		"var result = possiblyNull.RecursiveProperty is ReferenceThing x ? (x.ValueTypeProperty) : default;")]
 
 	// Conditional operators should also work with indexed access.
 	[TestCase(
@@ -110,11 +110,11 @@ internal sealed class IfNotNullTests : CodeFixVerifier
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.IfNotNull(ReferenceThing.CalculateStatic);",
-		"var result = possiblyNull is ReferenceThing ? ReferenceThing.CalculateStatic(possiblyNull) : default(ReferenceThing);")]
+		"var result = possiblyNull is ReferenceThing ? ReferenceThing.CalculateStatic(possiblyNull) : default;")]
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.RecursiveProperty.IfNotNull(ReferenceThing.CalculateStatic);",
-		"var result = possiblyNull.RecursiveProperty is ReferenceThing value ? ReferenceThing.CalculateStatic(value) : default(ReferenceThing);")]
+		"var result = possiblyNull.RecursiveProperty is ReferenceThing value ? ReferenceThing.CalculateStatic(value) : default;")]
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.IfNotNull(ReferenceThing.CalculateStatic, ReferenceThing.Factory);",
@@ -128,15 +128,15 @@ internal sealed class IfNotNullTests : CodeFixVerifier
 	[TestCase(
 		"(ValueThing?) new ValueThing()",
 		"var result = possiblyNull.IfNotNull((ValueThing x) => x.ValueTypeProperty);",
-		"var result = possiblyNull?.ValueTypeProperty ?? default(int);")]
+		"var result = possiblyNull?.ValueTypeProperty ?? default;")]
 	[TestCase(
 		"(ValueThing?) new ValueThing()",
 		"var result = possiblyNull.IfNotNull((ValueThing x) => x.RecursiveProperty);",
-		"var result = possiblyNull?.RecursiveProperty ?? default(ValueThing);")]
+		"var result = possiblyNull?.RecursiveProperty ?? default;")]
 	[TestCase(
 		"(ValueThing?) new ValueThing()",
 		"var result = IfNotNullExtensionMethod.IfNotNull(possiblyNull, (ValueThing x) => x.ValueTypeProperty);",
-		"var result = possiblyNull?.ValueTypeProperty ?? default(int);")]
+		"var result = possiblyNull?.ValueTypeProperty ?? default;")]
 	[TestCase(
 		"(ValueThing?) new ValueThing()",
 		"var result = possiblyNull.IfNotNull((ValueThing x) => x.ValueTypeProperty, 0);",
@@ -194,11 +194,11 @@ internal sealed class IfNotNullTests : CodeFixVerifier
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.IfNotNull(x => x.CalculateValue(x));",
-		"var result = possiblyNull is ReferenceThing ? possiblyNull.CalculateValue(possiblyNull) : default(ReferenceThing);")]
+		"var result = possiblyNull is ReferenceThing ? possiblyNull.CalculateValue(possiblyNull) : default;")]
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.RecursiveProperty.IfNotNull(x => x.CalculateValue(x));",
-		"var result = possiblyNull.RecursiveProperty is ReferenceThing x ? x.CalculateValue(x) : default(ReferenceThing);")]
+		"var result = possiblyNull.RecursiveProperty is ReferenceThing x ? x.CalculateValue(x) : default;")]
 
 	// This cast makes the call equivalent to the null-conditional operator, which means that
 	// pattern matching is unnecessary and the cast can be discarded.
@@ -264,7 +264,7 @@ internal sealed class IfNotNullTests : CodeFixVerifier
 	public void ConditionalAccessInvocation()
 	{
 		const string invalidCall = "var result = possiblyNull?.IfNotNull(x => x.ValueTypeProperty);";
-		const string fixedCall = "var result = possiblyNull?.ValueTypeProperty ?? default(int);";
+		const string fixedCall = "var result = possiblyNull?.ValueTypeProperty ?? default;";
 		var invalidProgram = $$"""
 			{{c_preamble}}
 			namespace TestProgram
@@ -321,12 +321,12 @@ internal sealed class IfNotNullTests : CodeFixVerifier
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.IfNotNull(x => ReferenceThing.CalculateStatic(x)).IfNotNull(x => ReferenceThing.CalculateStatic(x));",
-		"var result = (possiblyNull is ReferenceThing ? ReferenceThing.CalculateStatic(possiblyNull) : default(ReferenceThing)) is ReferenceThing x1 ? ReferenceThing.CalculateStatic(x1) : default(ReferenceThing);",
+		"var result = (possiblyNull is ReferenceThing ? ReferenceThing.CalculateStatic(possiblyNull) : default) is ReferenceThing x1 ? ReferenceThing.CalculateStatic(x1) : default;",
 		17, 17)]
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.IfNotNull(ReferenceThing.CalculateStatic).IfNotNull(ReferenceThing.CalculateStatic);",
-		"var result = (possiblyNull is ReferenceThing ? ReferenceThing.CalculateStatic(possiblyNull) : default(ReferenceThing)) is ReferenceThing value ? ReferenceThing.CalculateStatic(value) : default(ReferenceThing);",
+		"var result = (possiblyNull is ReferenceThing ? ReferenceThing.CalculateStatic(possiblyNull) : default) is ReferenceThing value ? ReferenceThing.CalculateStatic(value) : default;",
 		17, 17)]
 	public void MultipleMethodCalls(string possiblyNull, string call, string fixedCall, int firstColumn, int secondColumn)
 	{

--- a/tests/Faithlife.Analyzers.Tests/IfNotNullTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/IfNotNullTests.cs
@@ -260,6 +260,54 @@ internal sealed class IfNotNullTests : CodeFixVerifier
 		VerifyCSharpFix(invalidProgram, validProgram);
 	}
 
+	[Test]
+	public void ConditionalAccessInvocation()
+	{
+		const string invalidCall = "var result = possiblyNull?.IfNotNull(x => x.ValueTypeProperty);";
+		const string fixedCall = "var result = possiblyNull?.ValueTypeProperty ?? default(int);";
+		var invalidProgram = $$"""
+			{{c_preamble}}
+			namespace TestProgram
+			{
+				internal static class TestClass
+				{
+					public static void CallIfNotNull()
+					{
+						var possiblyNull = new ReferenceThing();
+						{{invalidCall}}
+					}
+				}
+			}
+			""";
+
+		var expected = new DiagnosticResult
+		{
+			Id = IfNotNullAnalyzer.DiagnosticId,
+			Message = "Prefer modern language features over IfNotNull usage",
+			Severity = DiagnosticSeverity.Info,
+			Locations = [new DiagnosticResultLocation("Test0.cs", s_preambleLength + 8, 30)],
+		};
+
+		VerifyCSharpDiagnostic(invalidProgram, expected);
+
+		var validProgram = $$"""
+			{{c_preamble}}
+			namespace TestProgram
+			{
+				internal static class TestClass
+				{
+					public static void CallIfNotNull()
+					{
+						var possiblyNull = new ReferenceThing();
+						{{fixedCall}}
+					}
+				}
+			}
+			""".Replace("using Libronix.Utility.IfNotNull;\n", "", StringComparison.Ordinal);
+
+		VerifyCSharpFix(invalidProgram, validProgram);
+	}
+
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.IfNotNull(x => x.RecursiveProperty.IfNotNull(y => y.CalculateValue()));",


### PR DESCRIPTION
## Summary
- handle conditional-access IfNotNull code fixes without crashing
- add regression coverage for the conditional-access invocation form
- bump package version to 1.7.2

## Testing
- dotnet test tests/Faithlife.Analyzers.Tests/Faithlife.Analyzers.Tests.csproj --no-restore