### PR TITLE
Skip IfNotNull diagnostics in expression trees

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>1.7.2</VersionPrefix>
+    <VersionPrefix>1.7.3</VersionPrefix>
     <NoWarn>$(NoWarn);1591;1998;NU5105;CA1014;CA1508;CA1859;NU1507</NoWarn>
     <GitHubOrganization>Faithlife</GitHubOrganization>
     <RepositoryName>FaithlifeAnalyzers</RepositoryName>

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 1.7.3
+
+* Fix FL0010 false positives for `IfNotNull` usages inside `Expression<>` lambdas, where null-conditional access is not supported.
+
 ## 1.7.2
 
 * Fix FL0010 code-fix handling for conditional-access invocations such as `possiblyNull?.IfNotNull(...)` so they apply without crashing.

--- a/src/Faithlife.Analyzers/IfNotNullAnalyzer.cs
+++ b/src/Faithlife.Analyzers/IfNotNullAnalyzer.cs
@@ -23,7 +23,9 @@ public sealed class IfNotNullAnalyzer : DiagnosticAnalyzer
 			if (ifNotNullMethods.Length == 0)
 				return;
 
-			compilationStartAnalysisContext.RegisterSyntaxNodeAction(c => AnalyzeSyntax(c, ifNotNullMethods), SyntaxKind.InvocationExpression);
+			var expressionType = compilationStartAnalysisContext.Compilation.GetTypeByMetadataName("System.Linq.Expressions.Expression`1");
+
+			compilationStartAnalysisContext.RegisterSyntaxNodeAction(c => AnalyzeSyntax(c, ifNotNullMethods, expressionType), SyntaxKind.InvocationExpression);
 		});
 	}
 
@@ -31,7 +33,7 @@ public sealed class IfNotNullAnalyzer : DiagnosticAnalyzer
 
 	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [s_rule];
 
-	private static void AnalyzeSyntax(SyntaxNodeAnalysisContext context, ImmutableArray<ISymbol> ifNotNullMethods)
+	private static void AnalyzeSyntax(SyntaxNodeAnalysisContext context, ImmutableArray<ISymbol> ifNotNullMethods, INamedTypeSymbol? expressionType)
 	{
 		var syntax = (InvocationExpressionSyntax) context.Node;
 
@@ -40,7 +42,24 @@ public sealed class IfNotNullAnalyzer : DiagnosticAnalyzer
 			!ifNotNullMethods.Any(x => SymbolEqualityComparer.Default.Equals(x, methodSymbol.ReducedFrom) || SymbolEqualityComparer.Default.Equals(x, methodSymbol.ConstructedFrom)))
 			return;
 
+		if (expressionType is not null && IsInExpressionTree(context, syntax, expressionType))
+			return;
+
 		context.ReportDiagnostic(Diagnostic.Create(s_rule, syntax.GetLocation()));
+	}
+
+	private static bool IsInExpressionTree(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax syntax, INamedTypeSymbol expressionType)
+	{
+		foreach (var anonymousFunction in syntax.Ancestors().OfType<AnonymousFunctionExpressionSyntax>())
+		{
+			if (context.SemanticModel.GetTypeInfo(anonymousFunction, context.CancellationToken).ConvertedType is INamedTypeSymbol convertedType &&
+				SymbolEqualityComparer.Default.Equals(convertedType.OriginalDefinition, expressionType))
+			{
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private static readonly DiagnosticDescriptor s_rule = new(

--- a/tests/Faithlife.Analyzers.Tests/IfNotNullTests.cs
+++ b/tests/Faithlife.Analyzers.Tests/IfNotNullTests.cs
@@ -319,6 +319,33 @@ internal sealed class IfNotNullTests : CodeFixVerifier
 		VerifyCSharpFix(invalidProgram, validProgram);
 	}
 
+	[Test]
+	public void NoDiagnosticInExpressionTree()
+	{
+		var validProgram = $$"""
+			{{c_preamble}}
+			namespace TestProgram
+			{
+				internal static class TestClass
+				{
+					public static void CallIfNotNull()
+					{
+						Expression<Func<ReferenceThing, int>> expression = thing => thing.IfNotNull(x => x.ValueTypeProperty);
+						Expression<Func<ReferenceThing, Func<int>>> nestedExpression = thing => () => thing.IfNotNull(x => x.ValueTypeProperty);
+						AcceptExpression(thing => thing.IfNotNull(x => x.ValueTypeProperty));
+						AcceptNestedExpression(thing => () => thing.IfNotNull(x => x.ValueTypeProperty));
+					}
+
+					private static void AcceptExpression(Expression<Func<ReferenceThing, int>> expression) { }
+
+					private static void AcceptNestedExpression(Expression<Func<ReferenceThing, Func<int>>> expression) { }
+				}
+			}
+			""";
+
+		VerifyCSharpDiagnostic(validProgram);
+	}
+
 	[TestCase(
 		"new ReferenceThing()",
 		"var result = possiblyNull.IfNotNull(x => x.RecursiveProperty.IfNotNull(y => y.CalculateValue()));",
@@ -473,8 +500,14 @@ internal sealed class IfNotNullTests : CodeFixVerifier
 
 	private const string c_preamble = """
 		using System;
+		using System.Linq.Expressions;
 		using Libronix.Utility.IfNotNull;
 		using TestProgram;
+
+		namespace System.Linq.Expressions
+		{
+			public abstract class Expression<TDelegate>;
+		}
 
 		namespace Libronix.Utility.IfNotNull
 		{


### PR DESCRIPTION
IfNotNull calls inside expression trees cannot be replaced with null-conditional access because `Expression<>` does not support those operators. This keeps the analyzer from flagging usages that cannot be migrated safely.

The analyzer now detects when an `IfNotNull` invocation is inside a lambda converted to `System.Linq.Expressions.Expression<T>` and skips `FL0010` for that case. The regression coverage was expanded to verify direct expression-tree assignments, nested expression trees, and expressions passed into methods that accept `Expression<...>`.